### PR TITLE
Fix broken links in PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.MD
+++ b/PULL_REQUEST_TEMPLATE.MD
@@ -1,6 +1,6 @@
 This is a modified version of the [Contributing Guidelines](CONTRIBUTING.md).
 
-This pull request adheres to the repository's [Code of Conduct](CODE_OF_CONDUCT.md)
+This pull request adheres to the repository's [Code of Conduct](CODE_OF_CONDUCT.md).
 
 
 - [ ] I am an employee of the company mentioned and confirm all included details are correct

--- a/PULL_REQUEST_TEMPLATE.MD
+++ b/PULL_REQUEST_TEMPLATE.MD
@@ -1,6 +1,6 @@
-This is a modified version of the [Contributing Guidelines](CONTRIBUTING.md).
+This is a modified version of the [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md).
 
-This pull request adheres to the repository's [Code of Conduct](CODE_OF_CONDUCT.md).
+This pull request adheres to the repository's [Code of Conduct](https://github.com/remoteintech/remote-jobs/blob/master/CODE_OF_CONDUCT.md).
 
 
 - [ ] I am an employee of the company mentioned and confirm all included details are correct
@@ -8,7 +8,7 @@ This pull request adheres to the repository's [Code of Conduct](CODE_OF_CONDUCT.
 - [ ] You know your alphabet - company is listed in alphabetical order in the README
 - [ ] The company directly hires employees. No bootcamps / freelance sites / etc
 - [ ] The company added hires remote employees, or positions are available to remote workers and are clearly illustrated as such
-- [ ] A [company profile](company-profiles/example.md) is included - __Required__ for new additions. (This can be a basic outline but at least something please)
+- [ ] A [company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md) is included - __Required__ for new additions. (This can be a basic outline but at least something please)
 - [ ] Any missing parts from the profile, please use `<Unknown>` to allow for future completion
 - [ ] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
 - [ ] __Region__ details any restrictions to applicants based on geography

--- a/PULL_REQUEST_TEMPLATE.MD
+++ b/PULL_REQUEST_TEMPLATE.MD
@@ -1,6 +1,6 @@
-This is a modified version of the [Contributing Guidelines](/CONTRIBUTING.md).
+This is a modified version of the [Contributing Guidelines](CONTRIBUTING.md).
 
-This pull request adheres to the repository's [Code of Conduct](/CODE_OF_CONDUCT.md)
+This pull request adheres to the repository's [Code of Conduct](CODE_OF_CONDUCT.md)
 
 
 - [ ] I am an employee of the company mentioned and confirm all included details are correct
@@ -8,8 +8,8 @@ This pull request adheres to the repository's [Code of Conduct](/CODE_OF_CONDUCT
 - [ ] You know your alphabet - company is listed in alphabetical order in the README
 - [ ] The company directly hires employees. No bootcamps / freelance sites / etc
 - [ ] The company added hires remote employees, or positions are available to remote workers and are clearly illustrated as such
-- [ ] A [company profile](/company-profiles/example.md) is included - __Required__ for new additions. (This can be a basic outline but at least something please)
-- [ ] Any missing parts from the profile, please use \<Unknown\> to allow for future completion
+- [ ] A [company profile](company-profiles/example.md) is included - __Required__ for new additions. (This can be a basic outline but at least something please)
+- [ ] Any missing parts from the profile, please use `<Unknown>` to allow for future completion
 - [ ] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
 - [ ] __Region__ details any restrictions to applicants based on geography
 - [ ] __How to apply__ details the best approach for new applications, page on site where open position are listed, and any other help available for job hunters


### PR DESCRIPTION
I've copied the modified PR template below.  Compare its links against other recent PRs:  they work here, but point to broken pages like https://github.com/CODE_OF_CONDUCT.md elsewhere.

---

This is a modified version of the [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md).

This pull request adheres to the repository's [Code of Conduct](https://github.com/remoteintech/remote-jobs/blob/master/CODE_OF_CONDUCT.md).


- [ ] I am an employee of the company mentioned and confirm all included details are correct
- [ ] This PR contains housekeeping only (URL edits, copy changes etc)
- [ ] You know your alphabet - company is listed in alphabetical order in the README
- [ ] The company directly hires employees. No bootcamps / freelance sites / etc
- [ ] The company added hires remote employees, or positions are available to remote workers and are clearly illustrated as such
- [ ] A [company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md) is included - __Required__ for new additions. (This can be a basic outline but at least something please)
- [ ] Any missing parts from the profile, please use `<Unknown>` to allow for future completion
- [ ] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
- [ ] __Region__ details any restrictions to applicants based on geography
- [ ] __How to apply__ details the best approach for new applications, page on site where open position are listed, and any other help available for job hunters
