### PR TITLE
Add link to the grid profile in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Teleport | http://teleport.org/ |
 Telerik | http://www.telerik.com/ |
 Tenable | http://www.tenable.com/ |
 Test Double | http://testdouble.com/ |
-[The Grid](/company-profiles/thegrid.md)) | https://thegrid.io/ | Worldwide
+[The Grid](/company-profiles/thegrid.md) | https://thegrid.io/ | Worldwide
 The Publisher Desk | http://www.publisherdesk.com |
 The Remote Lab | http://theremotelab.io |
 [The Scale Factory](/company-profiles/thescalefactory.md) | http://www.scalefactory.com/ | UK |

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Teleport | http://teleport.org/ |
 Telerik | http://www.telerik.com/ |
 Tenable | http://www.tenable.com/ |
 Test Double | http://testdouble.com/ |
-The Grid | https://thegrid.io/ | Worldwide
+[The Grid](/company-profiles/thegrid.md)) | https://thegrid.io/ | Worldwide
 The Publisher Desk | http://www.publisherdesk.com |
 The Remote Lab | http://theremotelab.io |
 [The Scale Factory](/company-profiles/thescalefactory.md) | http://www.scalefactory.com/ | UK |


### PR DESCRIPTION
This is a modified version of the [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md).

This pull request adheres to the repository's [Code of Conduct](https://github.com/remoteintech/remote-jobs/blob/master/CODE_OF_CONDUCT.md).


- [x] I am an employee of the company mentioned and confirm all included details are correct
- [x] This PR contains housekeeping only (URL edits, copy changes etc)
- [x] You know your alphabet - company is listed in alphabetical order in the README
- [x] The company directly hires employees. No bootcamps / freelance sites / etc
- [x] The company added hires remote employees, or positions are available to remote workers and are clearly illustrated as such
- [x] A [company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md) is included - __Required__ for new additions. (This can be a basic outline but at least something please)
- [x] Any missing parts from the profile, please use `<Unknown>` to allow for future completion
- [x] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
- [x] __Region__ details any restrictions to applicants based on geography
- [x] __How to apply__ details the best approach for new applications, page on site where open position are listed, and any other help available for job hunters
