### PR TITLE
Validate company sort order in readme; try out comment bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ Bulut Yazilim | https://bulutyazilim.com/ | Worldwide
 BuySellAds | https://www.buysellads.com/ |
 [Canonical](/company-profiles/canonical.md) | http://www.canonical.com/ | Worldwide
 Carbon Black | https://www.carbonblack.com/ | USA, Offices in Boston, MA
-[Codestunts](/company-profiles/codestunts.md) | https://codestunts.com/ | Worldwide
 Cards Against Humanity | https://cardsagainsthumanity.com/ |
 [CareMessage](/company-profiles/caremessage.md) | http://caremessage.org/careers | Worldwide
 [CartoDB](/company-profiles/cartodb.md) | https://cartodb.com/ | Worldwide
@@ -81,6 +80,7 @@ CircleCI | https://circleci.com/ |
 [Codea IT](/company-profiles/codea-it.md) | http://www.codeait.com | Worldwide
 [CodePen](/company-profiles/codepen.md) | https://codepen.io | Worldwide
 Codeship | https://codeship.com/ |
+[Codestunts](/company-profiles/codestunts.md) | https://codestunts.com/ | Worldwide
 [Colivre](/company-profiles/colivre.md) | http://colivre.coop.br/ | Worldwide
 Collabora | https://www.collabora.com/ |
 Compose | https://www.compose.io/ |
@@ -88,19 +88,19 @@ Compose | https://www.compose.io/ |
 Consumer Financial Protection Bureau | http://www.consumerfinance.gov |
 Continu | https://www.continu.co/ |
 [Conversio](/company-profiles/conversio.md) | https://conversio.com/ | Worldwide
+[Convert](/company-profiles/convert.md) | https://www.convert.com | Worldwide
 Core-Apps | http://www.core-apps.com/ | USA
 CoreOS | https://coreos.com/ |
-[Convert](/company-profiles/convert.md) | https://www.convert.com | Worldwide
 [Corgibytes](/company-profiles/corgibytes.md) | http://corgibytes.com | US East Coast
-[Customer.io](/company-profiles/customer-io.md) | https://customer.io | Worldwide
 [Crew](/company-profiles/crew.md) | https://crew.co | Worldwide
 Crossover | https://www.crossover.com | Worldwide
 [CrowdTangle](/company-profiles/crowdtangle.md) | http://crowdtangle.com | USA
+[Customer.io](/company-profiles/customer-io.md) | https://customer.io | Worldwide
 [Dalenys](/company-profiles/dalenys.md) | https://dalenys.com/ | Europe
-Datica | https://datica.com/ |
-[Datadog](/company-profiles/datadog.md) | https://www.datadoghq.com/ | Worldwide
 [Data Science Brigade](/company-profiles/data-science-brigade.md) | http://datasciencebr.com/ | Worldwide
+[Datadog](/company-profiles/datadog.md) | https://www.datadoghq.com/ | Worldwide
 DataStax | http://www.datastax.com/ |
+Datica | https://datica.com/ |
 DealDash | http://www.dealdash.com |
 Delighted | https://delighted.com |
 [Dgraph](/company-profiles/dgraph.md) | https://dgraph.io/ | Americas

--- a/README.md
+++ b/README.md
@@ -162,10 +162,10 @@ Hanno | https://hanno.co/ |
 Happy Cog | http://happycog.com/ | USA
 [Harvest](/company-profiles/harvest.md) | https://www.getharvest.com/ | Worldwide
 HashiCorp | https://www.hashicorp.com/ |
+[HE:labs](/company-profiles/he-labs.md) | https://www.helabs.com | Worldwide
 Healthfinch | http://www.healthfinch.com/ |
 [Heap](/company-profiles/heap.md) | https://heapanalytics.com/ | Worldwide
 Help Scout | https://www.helpscout.net/ |
-[HE:labs](/company-profiles/he-labs.md) | https://www.helabs.com | Worldwide
 Heroku | https://www.heroku.com/ |
 [Hireology](/company-profiles/hireology.md) | https://www.hireology.com | United States
 Honeybadger | https://www.honeybadger.io/ |
@@ -292,10 +292,9 @@ Soostone | http://www.soostone.com/ |
 [Spoqa](/company-profiles/spoqa.md) | http://www.spoqa.com/ | South Korea and Japan
 [Spreedly](/company-profiles/spreedly.md) | https://spreedly.com/ | United States
 [Stack Exchange](/company-profiles/stack-exchange.md) | http://stackexchange.com/ | Worldwide
-[Stencil](/company-profiles/stencil.md) | https://getstencil.com/ | United States and Canada
-Stitch Fix  | https://www.stitchfix.com |
 [Stairlin](/company-profiles/stairlin.md) | https://www.stairlin.com/ | Worldwide
-Stitch Fix  | https://www.stitchfix.com |
+[Stencil](/company-profiles/stencil.md) | https://getstencil.com/ | United States and Canada
+Stitch Fix | https://www.stitchfix.com |
 [Stripe](/company-profiles/stripe.md) | https://stripe.com/ | Worldwide
 Strongloop | https://strongloop.com/ |
 [StudySoup](/company-profiles/studysoup.md) | https://studysoup.com/ | Worldwide
@@ -349,7 +348,7 @@ WikiHow | http://www.wikihow.com/wikiHow:About-wikiHow | PST Timezone
 Wombat Security Technologies | https://www.wombatsecurity.com/ | USA
 Word to the Wise | https://wordtothewise.com |
 X-Team | http://x-team.com/ |
-YouCanBook.me Ltd | https://youcanbook.me |
 Yonder | https://www.yonder.io | Worldwide
+YouCanBook.me Ltd | https://youcanbook.me |
 [Zapier](/company-profiles/zapier.md) | https://zapier.com/ | Worldwide
 [Zeit.io](/company-profiles/zeit-io.md) | http://zeit.io/ | Germany, The Netherlands, Spain, Chile

--- a/bin/validate.js
+++ b/bin/validate.js
@@ -10,10 +10,20 @@ let errorCount = 0;
 
 
 /**
+ * Accept an optional directory name where the content files live.
+ */
+const contentPath = (
+	process.argv[ 2 ]
+		? path.resolve( process.argv[ 2 ] )
+		: path.join( __dirname, '.. ' )
+);
+
+
+/**
  * Build list of Markdown files containing company profiles.
  */
 
-const profilesPath = path.join( __dirname, '..', 'company-profiles' );
+const profilesPath = path.join( contentPath, 'company-profiles' );
 const profileFilenames = fs.readdirSync( profilesPath );
 
 
@@ -24,7 +34,7 @@ const profileFilenames = fs.readdirSync( profilesPath );
 const readmeCompanies = [];
 
 const readmeMarkdown = fs.readFileSync(
-	path.join( __dirname, '..', 'README.md' ),
+	path.join( contentPath, 'README.md' ),
 	'utf8'
 );
 

--- a/bin/validate.js
+++ b/bin/validate.js
@@ -15,7 +15,7 @@ let errorCount = 0;
 const contentPath = (
 	process.argv[ 2 ]
 		? path.resolve( process.argv[ 2 ] )
-		: path.join( __dirname, '.. ' )
+		: path.join( __dirname, '..' )
 );
 
 

--- a/bin/validate.js
+++ b/bin/validate.js
@@ -61,7 +61,7 @@ $( 'tr' ).each( ( i, tr ) => {
 	if ( ! entry.name ) {
 		readmeError(
 			'Missing company name: %s',
-			$( tr ).html()
+			$( tr ).html().replace( /\n/g, '' )
 		);
 	}
 

--- a/bin/validate.js
+++ b/bin/validate.js
@@ -38,6 +38,8 @@ function readmeError( msg, ...params ) {
 	);
 }
 
+let lastCompanyName = null;
+
 $( 'tr' ).each( ( i, tr ) => {
 	if ( i === 0 ) {
 		// Skip the table header row.
@@ -64,6 +66,18 @@ $( 'tr' ).each( ( i, tr ) => {
 			$( tr ).html().replace( /\n/g, '' )
 		);
 	}
+
+	if (
+		lastCompanyName &&
+		entry.name.toLowerCase() < lastCompanyName.toLowerCase()
+	) {
+		readmeError(
+			'Company is listed out of order: "%s" (should be before "%s")',
+			entry.name,
+			lastCompanyName
+		);
+	}
+	lastCompanyName = entry.name;
 
 	const profileLink = $td.eq( 0 ).find( 'a' ).attr( 'href' );
 


### PR DESCRIPTION
This PR makes some changes to validate the sort order of companies in the readme.

As with https://github.com/remoteintech/remote-jobs/pull/378, it should fail at first because the existing data doesn't pass the new validation, then I'll make another commit to clean things up.