### PR TITLE
Make company headings consistent

### DIFF
--- a/bin/validate.js
+++ b/bin/validate.js
@@ -20,6 +20,22 @@ const contentPath = (
 
 
 /**
+ * Define the heading names expected in company profiles.
+ */
+const headingsRequired = [
+	'Company blurb',
+];
+const headingsOptional = [
+	'Company size',
+	'Remote status',
+	'Region',
+	'Company technologies',
+	'Office locations',
+	'How to apply',
+];
+
+
+/**
  * Build list of Markdown files containing company profiles.
  */
 
@@ -181,6 +197,34 @@ profileFilenames.forEach( filename => {
 	) {
 		error( 'No link to company profile from readme' );
 	}
+
+	// Build and validate list of headings contained in this Markdown profile.
+
+	const profileHeadings = [];
+
+	$( 'h2' ).each( ( i, el ) => {
+		const headingName = $( el ).html();
+		profileHeadings.push( headingName );
+		if (
+			headingsRequired.indexOf( headingName ) === -1 &&
+			headingsOptional.indexOf( headingName ) === -1
+		) {
+			error(
+				'Invalid heading name: "%s".  Expected one of: %s',
+				headingName,
+				JSON.stringify( headingsRequired.concat( headingsOptional ) )
+			);
+		}
+	} );
+
+	headingsRequired.forEach( headingName => {
+		if ( profileHeadings.indexOf( headingName ) === -1 ) {
+			error(
+				'Required heading "%s" not found.',
+				headingName
+			);
+		}
+	} );
 } );
 
 console.log();

--- a/bin/validate.js
+++ b/bin/validate.js
@@ -142,6 +142,8 @@ $( 'tr' ).each( ( i, tr ) => {
  * Scan the individual Markdown files containing the company profiles.
  */
 
+const allProfileHeadings = {};
+
 profileFilenames.forEach( filename => {
 	function error( msg, ...params ) {
 		errorCount++;
@@ -215,6 +217,11 @@ profileFilenames.forEach( filename => {
 				JSON.stringify( headingsRequired.concat( headingsOptional ) )
 			);
 		}
+		// Track headings across all profiles
+		if ( ! allProfileHeadings[ headingName ] ) {
+			allProfileHeadings[ headingName ] = [];
+		}
+		allProfileHeadings[ headingName ].push( filename );
 	} );
 
 	headingsRequired.forEach( headingName => {
@@ -226,6 +233,17 @@ profileFilenames.forEach( filename => {
 		}
 	} );
 } );
+
+if ( process.env.REPORT_PROFILE_HEADINGS ) {
+	console.log();
+	console.log(
+		'Profile headings by count (%d total profiles):',
+		profileFilenames.length
+	);
+	Object.keys( allProfileHeadings ).forEach( heading => {
+		console.log( '%s: %d', heading, allProfileHeadings[ heading ].length )
+	} );
+}
 
 console.log();
 console.log(

--- a/company-profiles/10up.md
+++ b/company-profiles/10up.md
@@ -30,7 +30,7 @@ We have employees all around the world, from across the US to the UK to South Af
 * Nginx
 * Memcache
 
-## Office Locations
+## Office locations
 
 None; or everywhere!
 

--- a/company-profiles/17hats.md
+++ b/company-profiles/17hats.md
@@ -20,7 +20,7 @@ Worldwide
 
 iOS, React, Knockout, Rails, Perl, HTML, Sql, Ruby, JQuery
 
-## Office Locations
+## Office locations
 
 Not known
 

--- a/company-profiles/18f.md
+++ b/company-profiles/18f.md
@@ -36,7 +36,7 @@ U.S. citizens, non-citizens who are nationals of the U.S., or people who have be
 
 Ruby, Python, HTML, CSS, JavaScript
 
-## Office Locations
+## Office locations
 
 Federal buildings in San Francisco, Chicago, New York City, and Washington D.C.
 

--- a/company-profiles/ably.md
+++ b/company-profiles/ably.md
@@ -33,7 +33,7 @@ The bulk of our engineering team is in Europe so we generally prefer candidates 
 * We make extensive use of a wide array of AWS services
 * We host our code in Git
 
-## Office Locations
+## Office locations
 
 London, United Kingdom
 

--- a/company-profiles/acquia.md
+++ b/company-profiles/acquia.md
@@ -26,7 +26,7 @@ Worldwide - Acquia is an international company with office locations around the 
 - JavaScript
 - Ruby
 
-## Office Locations
+## Office locations
 
 - Boston, MA, USA (Headquarters)
 - Gent, Belgium

--- a/company-profiles/ad-hoc.md
+++ b/company-profiles/ad-hoc.md
@@ -24,7 +24,7 @@ USA only for the time being: many of our contracts with the US government requir
 - HTML
 - CSS
 
-## Office Locations
+## Office locations
 
 None! We have a small coworking space for our DC team, but otherwise everyone works remotely.
 

--- a/company-profiles/agflow.md
+++ b/company-profiles/agflow.md
@@ -22,7 +22,7 @@ Main office is located at Geneva, Switzerland. There is one small office in Wroc
 * Redis
 * React
 
-## Office Locations
+## Office locations
 [Geneva, CH](https://www.google.ch/maps/place/Boulevard+de+Saint-Georges+72,+1205+Genève/)
 
 ## How to apply

--- a/company-profiles/agilebits.md
+++ b/company-profiles/agilebits.md
@@ -20,7 +20,7 @@ Worldwide. Right now we have folks distributed throughout North America and Euro
 
 \<Unknown\>
 
-## Office Locations
+## Office locations
 
 Toronto, Ontario
 

--- a/company-profiles/aha.md
+++ b/company-profiles/aha.md
@@ -23,7 +23,7 @@ Worldwide
 
 Ruby on Rails, React, jQuery
 
-## Office Locations
+## Office locations
 
 Worldwide
 

--- a/company-profiles/algorithmia.md
+++ b/company-profiles/algorithmia.md
@@ -25,7 +25,7 @@ Worldwide, but we work primarily on US timezones.
 - Kubernetes
 - Docker
 
-## Office Locations
+## Office locations
 
 - Seattle, WA
 

--- a/company-profiles/allydvm.md
+++ b/company-profiles/allydvm.md
@@ -24,7 +24,7 @@ USA
 
 Ruby and RoR, Javascript, AngularJS, Coffeescript, iOS, Android, MySQL, HTML/CSS, Java and Spring
 
-## Office Locations
+## Office locations
 
 \<Unknown\>
 

--- a/company-profiles/alphasights.md
+++ b/company-profiles/alphasights.md
@@ -29,7 +29,7 @@ Our remote engineers work the same hours as our New York and London offices depe
 * PostgreSQL
 * Git
 
-## Office Locations
+## Office locations
 
 Our engineering offices are located in New York City and London. We have other offices in Dubai, Shanghai, Seoul, and San Francisco.
 

--- a/company-profiles/and-yet.md
+++ b/company-profiles/and-yet.md
@@ -20,7 +20,7 @@ We employ several strategies that ensure inclusive and collaborative environment
 * Jade
 * Stylus
 
-## Office Locations
+## Office locations
 [Richland, WA](https://www.google.com/maps/place/110+Gage+Blvd,+Richland,+WA+99352)
 
 ## How to apply

--- a/company-profiles/anexus.md
+++ b/company-profiles/anexus.md
@@ -27,7 +27,7 @@ Latin America - Anexus is a regional company with offices in Costa Rica but a te
 - ReactJS
 - Symfony
 
-## Office Locations
+## Office locations
 
 - San Jose, Costa Rica (Headquarters)
 

--- a/company-profiles/apartment-therapy.md
+++ b/company-profiles/apartment-therapy.md
@@ -30,7 +30,7 @@ US-based employees only.
 
 CTO Scott Trudeau wrote a gist about their [stack, product team, and mentions working remotely](https://gist.github.com/sstrudeau/f563dc72739e9e047de5)
 
-## Office Locations
+## Office locations
 
 Company office in [NYC - 270 Lafayette St Fl 12 (Prince St.), New York, NY 10012, United States](https://www.google.com/maps/place/Apartment+Therapy/@40.7240504,-73.9965837,20z/data=!4m7!1m4!3m3!1s0x89c27c75f5d73d85:0x4fd9ab773fad77d1!2sProject+Real+Apartment+Treatment,+55+N+Ocean+Ave+%23+2,+Freeport,+NY+11520!3b1!3m1!1s0x0000000000000000:0x9f96cb380f7dbcf7)
 

--- a/company-profiles/appstractor.md
+++ b/company-profiles/appstractor.md
@@ -22,7 +22,7 @@ Worldwide
 
 LAMP
 
-## Office Locations
+## Office locations
 
 US, UK, Israel offices
 

--- a/company-profiles/art-and-logic.md
+++ b/company-profiles/art-and-logic.md
@@ -38,7 +38,7 @@ We work with an extensive range of languages and technologies.
 * C#
 * Git
 
-## Office Locations
+## Office locations
 
 Headquarters in Pasadena, CA and offices throughout the US. 
 

--- a/company-profiles/artefactual.md
+++ b/company-profiles/artefactual.md
@@ -24,7 +24,7 @@ UTC-8 to UTC+2
 
 PHP, Python, JavaScript, git, MySQL, HTML, CSS, Django, Symfony, Ansible, Docker, Jenkins, Nginx, Azure, AWS, Ubuntu, CentOS, RedHat.
 
-## Office Locations
+## Office locations
 
 New Westminster, BC.
 

--- a/company-profiles/articulate.md
+++ b/company-profiles/articulate.md
@@ -21,7 +21,7 @@ Worldwide
 
 .NET, C#
 
-## Office Locations
+## Office locations
 
 244 5th Avenue, Suite 2960, New York, NY 10001
 

--- a/company-profiles/astronomer.md
+++ b/company-profiles/astronomer.md
@@ -28,7 +28,7 @@ A good amount of our code is open source on [GitHub](https://github.com/astronom
 
 We publish a variety of technical posts on [our blog](https://www.astronomer.io/blog) and [Medium publication](https://medium.com/the-astronomer-journey/latest).
 
-## Office Locations
+## Office locations
 
 Cincinnati, OH
 

--- a/company-profiles/auth0.md
+++ b/company-profiles/auth0.md
@@ -35,7 +35,7 @@ Also be familiar with:
 * JSON Web Tokens
 * OAuth, OpenID Connect
 
-## Office Locations
+## Office locations
 
 8 office locations
 

--- a/company-profiles/automattic.md
+++ b/company-profiles/automattic.md
@@ -26,7 +26,7 @@ Worldwide - our team members hail from all over, every continent except Antarcti
 
 WordPress, [JavaScript (Node/React/Redux)](https://ma.tt/2015/11/dance-to-calypso/), PHP, Spark, Kafka, Elasticsearch, Impala/Hive, MySQL, Java, Python
 
-## Office Locations
+## Office locations
 
 We no longer have an official physical office.
 

--- a/company-profiles/axelerant.md
+++ b/company-profiles/axelerant.md
@@ -27,7 +27,7 @@ Worldwide - Axelerant team members work from home, cafes, or co-working spaces.
 * JavaScript
 * Ruby
 
-## Office Locations
+## Office locations
 
 * Atlanta, United States
 * Gurgaon, India

--- a/company-profiles/balsamiq.md
+++ b/company-profiles/balsamiq.md
@@ -20,7 +20,7 @@ We currently have employees in the U.S. and in several European countries.
 
 \<Unknown\>
 
-## Office Locations
+## Office locations
 
 We have one office in Bologna, Italy. All other employees work from home.
 

--- a/company-profiles/bandcamp.md
+++ b/company-profiles/bandcamp.md
@@ -21,7 +21,7 @@ Worldwide
 
 unknown
 
-## Office Locations
+## Office locations
 
 There is no Bandcamp office. Our team is sprinkled throughout the world.
 

--- a/company-profiles/bandzoogle.md
+++ b/company-profiles/bandzoogle.md
@@ -23,7 +23,7 @@ Worldwide - Bandzoogle is remote-only.
 
 RoR, Ember.js, APIs
 
-## Office Locations
+## Office locations
 
 No physical location.
 

--- a/company-profiles/baremetrics.md
+++ b/company-profiles/baremetrics.md
@@ -22,7 +22,7 @@ Worldwide.
 
 PHP, jQuery
 
-## Office Locations
+## Office locations
 
 None, 100% remote.
 

--- a/company-profiles/basecamp.md
+++ b/company-profiles/basecamp.md
@@ -21,7 +21,7 @@ Worldwide
 
 Ruby, Rails, CoffeeScript, Backbone.js, Memcached, MySQL, S3
 
-## Office Locations
+## Office locations
 
 While people who work at Basecamp can live and work anywhere they want, about 14 of us work out of our Chicago headquarters.
 

--- a/company-profiles/big-cartel.md
+++ b/company-profiles/big-cartel.md
@@ -20,7 +20,7 @@ Currently we are only set up for US-based remote employees.
 
 Rails, Ember, JSON API, MySQL, Elasticsearch, Redis, Riak, Redshift
 
-## Office Locations
+## Office locations
 
 Salt Lake City, Utah
 

--- a/company-profiles/big-wheel-brigade.md
+++ b/company-profiles/big-wheel-brigade.md
@@ -22,7 +22,7 @@ US, currently.
 
 Rails, primarily, with some Wordpress clients.
 
-## Office Locations
+## Office locations
 
 Omaha, Nebraska, yo!
 

--- a/company-profiles/bitnami.md
+++ b/company-profiles/bitnami.md
@@ -27,7 +27,7 @@ We have employees all around the world, with the bulk of our engineering team in
 * We host our code in Git
 * We have a heavy bias towards deploying our services on Kubernetes
 
-## Office Locations
+## Office locations
 
 San Francisco, USA and Seville, Spain.
 

--- a/company-profiles/bitovi.md
+++ b/company-profiles/bitovi.md
@@ -18,7 +18,7 @@ A team of developers (and designers) located around the US, Canada, and Croatia.
 
 JavaScript, HTML, CSS, etc.
 
-## Office Locations
+## Office locations
 
 Headquarters in Chicago, USA.
 

--- a/company-profiles/black-tangent.md
+++ b/company-profiles/black-tangent.md
@@ -24,7 +24,7 @@ Worldwide
 
 Ruby on Rails, ReactJS, Elixir, Phoenix
 
-## Office Locations
+## Office locations
 
 There is no official office. Some of us choose to work in co-working space together when they're in the same city.
 

--- a/company-profiles/britecore.md
+++ b/company-profiles/britecore.md
@@ -29,7 +29,7 @@ Currently our Engineers and Staff work in the US and some are spread across the 
 - Jenkins
 - Vue.js, Knockout
 
-## Office Locations
+## Office locations
 
 BriteCore's head office is in Springfield, Missouri.
 

--- a/company-profiles/buffer.md
+++ b/company-profiles/buffer.md
@@ -24,7 +24,7 @@ Buffer employs people worldwide
 
 Redshift, Hadoop, MongoDB JavaScript, PHP, Underscore, Backbone.
 
-## Office Locations
+## Office locations
 
 No physical office, recently sold HQ and all employees work remotely.
 

--- a/company-profiles/canonical.md
+++ b/company-profiles/canonical.md
@@ -22,7 +22,7 @@ Worldwide, or "home based", their open vacancies can be search by [location or r
 Canonical use a variety of technologies across their range of products or services, the company are behind Ubuntu, the server, Desktop, and mobile operating system.
 Canonical has also created several important tools to help customers build, manage and scale their clouds. For telcos and enterprises, Landscape helps administrators deploy and manage Ubuntu clouds cost-effectively. And whether you are using your own cloud or someone else’s, Juju and MAAS drastically reduce the time, cost and complexity of deploying and scaling in any cloud environment.
 
-## Office Locations
+## Office locations
 
 Canonical Ltd - Douglas, IOM
 Canonical Group Ltd - London, UK

--- a/company-profiles/caremessage.md
+++ b/company-profiles/caremessage.md
@@ -20,7 +20,7 @@ CareMessage employs people worldwide
 
 Ruby, Rails, JavaScript, AngularJS, PostgreSQL, Redis
 
-## Office Locations
+## Office locations
 
 San Francisco
 

--- a/company-profiles/cartodb.md
+++ b/company-profiles/cartodb.md
@@ -40,7 +40,7 @@ CartoDB has a lovely [attributions page](https://cartodb.com/attributions/) with
 |   | Mapnik  |  |
 |   | CartoCSS  |  |
 
-## Office Locations
+## Office locations
 
 Madrid & NYC
 

--- a/company-profiles/casumo.md
+++ b/company-profiles/casumo.md
@@ -41,7 +41,7 @@ Our technology stack is not set in stone, but this is what we are currently usin
 - CQRS - Axon Framework
 - Git
 
-## Office Locations
+## Office locations
 
 - Swieqi, Malta
 - Barcelona, Spain

--- a/company-profiles/chargify.md
+++ b/company-profiles/chargify.md
@@ -23,7 +23,7 @@ Worldwide - Mainly US based employees but with one in Brazil and another in Aust
 
 RoR, AWS, Docker
 
-## Office Locations
+## Office locations
 
 Head office is located in Needham, MA
 

--- a/company-profiles/chef.md
+++ b/company-profiles/chef.md
@@ -20,7 +20,7 @@ Mainly USA but some UK
 
 Chef
 
-## Office Locations
+## Office locations
 
 Chef Seattle
 619 Western Ave, Suite 400

--- a/company-profiles/circonus.md
+++ b/company-profiles/circonus.md
@@ -28,7 +28,7 @@ Not specified.
 * Perl
 * Linux
 
-## Office Locations
+## Office locations
 
 Fulton, Maryland
 

--- a/company-profiles/citrusbyte.md
+++ b/company-profiles/citrusbyte.md
@@ -20,7 +20,7 @@ The main offices are in New York, San Francisco, Santa Monica, Portland and Seat
 * Python
 * Javascript
 
-## Office Locations
+## Office locations
 The main offices are in New York, San Francisco, Santa Monica, Portland and Seattle.
 
 ## How to apply

--- a/company-profiles/clevertech.md
+++ b/company-profiles/clevertech.md
@@ -20,7 +20,7 @@ Nearly 100 employees
 
 JS, node, Python, RoR, PHP, Java,
 
-## Office Locations
+## Office locations
 
 379 W Broadway, 2nd Floor, New York, NY
 

--- a/company-profiles/close-io.md
+++ b/company-profiles/close-io.md
@@ -21,7 +21,7 @@ overlap with US business hours.
 
 Python, JavaScript, HTML5/CSS, MongoDB, Elasticsearch, Postgres, AWS, Puppet
 
-## Office Locations
+## Office locations
 
 Palo Alto, CA
 

--- a/company-profiles/codea-it.md
+++ b/company-profiles/codea-it.md
@@ -24,7 +24,7 @@ Worldwide
 
 AngularJS, Node.js, Android (Java), iOS (Objective-c, Swift), HTML5, CSS, JavaScript, PHP, Ruby, React, Wordpress, C#, Sails.js, Python, .NET, MongoDB, Postgres, SQL 
 
-## Office Locations
+## Office locations
 
 Buenos Aires, Argentina
 

--- a/company-profiles/codepen.md
+++ b/company-profiles/codepen.md
@@ -26,7 +26,7 @@ Anywhere
 
 JavaScript, jQuery, React, Ruby on Rails, CloudFlare, AWS
 
-## Office Locations
+## Office locations
 
 The team is 100% remote, but there's a mailing address advertised at:
 

--- a/company-profiles/codestunts.md
+++ b/company-profiles/codestunts.md
@@ -1,6 +1,6 @@
 # Codestunts
 
-## Company Codestunts
+## Company blurb
 
 Codestunts connects freelance software developers with lean entrepreneurs and digital agencies. Our job is connect you with a merchant/buyer and guide from recruitment to payment and solving the possible problems between parties.
 

--- a/company-profiles/codestunts.md
+++ b/company-profiles/codestunts.md
@@ -20,7 +20,7 @@ Worldwide
 
 PHP, Node.js, MariaDB, Android, IOS 
 
-## Office Locations
+## Office locations
 
 The room where you read this line
 

--- a/company-profiles/cofense.md
+++ b/company-profiles/cofense.md
@@ -26,7 +26,7 @@ Worldwide, but remote technical roles are USA only.
 * AWS
 * Git
 
-## Office Locations
+## Office locations
 
 * Leesburg, VA, USA (Headquarters)
 * New York City, NY, USA

--- a/company-profiles/colivre.md
+++ b/company-profiles/colivre.md
@@ -24,7 +24,7 @@ We are open to members anywhere. *(We know the possible Mars One members will ha
 * Git
 * Server administration *(all meanings that could put here)*
 
-## Office Locations
+## Office locations
 
 Salvador, Bahia, Brasil.
 

--- a/company-profiles/consensys.md
+++ b/company-profiles/consensys.md
@@ -26,7 +26,7 @@ project (IPFS, Scala, Java, Go, Python, React, Elasticsearch, Rust...)
 
 For remote communication, Slack, Zoom, and Quip.
 
-## Office Locations
+## Office locations
 
 San Francisco, New York, Toronto, Bucharest, Dubai
 

--- a/company-profiles/conversio.md
+++ b/company-profiles/conversio.md
@@ -21,7 +21,7 @@ Worldwide
 Node.JS
 MongoDB
 
-## Office Locations
+## Office locations
 
 Devonshire House
 60 Goswell Road

--- a/company-profiles/convert.md
+++ b/company-profiles/convert.md
@@ -30,7 +30,7 @@ Convert.com is a 100% remote company and fully encourages remote friendly work. 
 - Vagrant
 - Webpack
 
-## Office Locations
+## Office locations
 No physical office, all employees work remotely.
 
 ## How to apply

--- a/company-profiles/corgibytes.md
+++ b/company-profiles/corgibytes.md
@@ -1,13 +1,12 @@
 # Corgibytes
 
-## Our mission
-
-To maintain and improve the world's existing code.
-
 ## Company blurb
 
 **Fixing & updating existing code is our speciality**
 Every member of the Corgibytes team is a consummate problem solver. We love tinkering, testing, and turning frustration into relief. Some call us craftsman. Others, code whisperers. We just have a knack for identifying problems and building solutions. Spaghetti code? We love it. Or, at least making it better.
+
+**Our mission**
+To maintain and improve the world's existing code.
 
 **Our vision**
 Codebases are nurtured to provide the highest value for the longest time.

--- a/company-profiles/crew.md
+++ b/company-profiles/crew.md
@@ -33,7 +33,7 @@ We use CakePHP, Rails, MySQL, LESS, and jQuery.
 And/or: Rails, Postgres, Redis, RSpec + Capybara, Sidekiq
 And/or: HTML, CSS/LESS, JS/jQuery
 
-## Office Locations
+## Office locations
 
 Montreal, Canada
 

--- a/company-profiles/crowdtangle.md
+++ b/company-profiles/crowdtangle.md
@@ -25,7 +25,7 @@ For technical hires, we're looking anywhere in the United States. For non-techni
 - DynamoDB
 - ElasticSearch
 
-## Office Locations
+## Office locations
 
 Offices arise when there is a critical mass in one city. So far, that's just New York.
 

--- a/company-profiles/customer-io.md
+++ b/company-profiles/customer-io.md
@@ -26,7 +26,7 @@ Worldwide! We have or have had people based in Germany, the UK, the US, and Cana
 * CSS
 * HTML
 
-## Office Locations
+## Office locations
 
 Portland, OR, USA
 

--- a/company-profiles/dalenys.md
+++ b/company-profiles/dalenys.md
@@ -38,7 +38,7 @@ MySQL
 Nginx
 Python
 
-## Office Locations
+## Office locations
 
 Amsterdam : Singel 373, 1012 WL, Amsterdam, Netherlands
 Paris (Levallois-Perret) : 55 rue Raspail, 92300, Levallois-Perret, France

--- a/company-profiles/dashboardhub.md
+++ b/company-profiles/dashboardhub.md
@@ -24,7 +24,7 @@ Worldwide
 - angular
 - material design
 
-## Office Locations
+## Office locations
 
 None; or everywhere!
 

--- a/company-profiles/data-science-brigade.md
+++ b/company-profiles/data-science-brigade.md
@@ -22,7 +22,7 @@ Worldwide - We have employees that work from the America to Europe, and even som
 - Django
 - Git
 
-## Office Locations
+## Office locations
 
 - Milan, Italy
 - São Paulo, Brazil

--- a/company-profiles/datadog.md
+++ b/company-profiles/datadog.md
@@ -24,7 +24,7 @@ Worldwide given job openings
 
 \<unknown\>
 
-## Office Locations
+## Office locations
 
 New York City - Headquarters
 Datadog, Inc. • 620 8th Ave, 45th Floor • New York, NY 10018

--- a/company-profiles/dgraph.md
+++ b/company-profiles/dgraph.md
@@ -16,7 +16,7 @@ We encourage remote work. We even cover the expenses for a co-working space in t
 
 North and South America. We like to have at least a 4-hour overlap when we can coordinate on a project if the need be.
 
-## Company Technologies
+## Company technologies
 
 Go
 
@@ -24,7 +24,7 @@ Go
 
 We don't have a central office. Most of the team would work out of SF or Vancouver.
 
-## How to Apply
+## How to apply
 
 Have a look at the [jobs](http://dgraph.io/#jobs) section on our website. If this looks interesting drop us an email at [join@dgraph.io](join@dgraph.io).
 

--- a/company-profiles/dgraph.md
+++ b/company-profiles/dgraph.md
@@ -8,7 +8,7 @@ At DGraph, we have built a scalable, distributed, low latency, high throughput G
 
 Four-member team as shown on [team page](http://dgraph.io/#team).
 
-## Remote Status
+## Remote status
 
 We encourage remote work. We even cover the expenses for a co-working space in the city of your choice.
 
@@ -20,7 +20,7 @@ North and South America. We like to have at least a 4-hour overlap when we can c
 
 Go
 
-## Office Locations
+## Office locations
 
 We don't have a central office. Most of the team would work out of SF or Vancouver.
 

--- a/company-profiles/digitalocean.md
+++ b/company-profiles/digitalocean.md
@@ -20,7 +20,7 @@ Worldwide
 
 Go, Perl, Ruby, Kafka, Consul, Chef, Prometheus, MemSQL, MySQL, Looker, Rsyslog, Open vSwitch, Libvirt, KVM, chef, git
 
-## Office Locations
+## Office locations
 
 DigitalOcean, Inc. 101 Ave of the Americas 10th Floor New York
 

--- a/company-profiles/discourse.md
+++ b/company-profiles/discourse.md
@@ -29,7 +29,7 @@ Discourse is a JavaScript application that runs in your web browser, using the E
 
 The server side of Discourse is Ruby on Rails backed by a Postgres database and Redis cache. You can deploy our standard Discourse Docker container on any virtualized cloud server (digital ocean, amazon ec2, rackspace, azure) with 1 GB RAM.
 
-## Office Locations
+## Office locations
 
 Entirely remote, team is distributed with employees in Australia, USA, Brazil, Canada, France, Singapore, India, New Zealand, Austria, and Norway.
 

--- a/company-profiles/dnsimple.md
+++ b/company-profiles/dnsimple.md
@@ -25,7 +25,7 @@ We are open to new team members living anywhere in the world.
 
 Our web applications are typically developed in Ruby or Go. Our DNS servers are written in Erlang. We use Chef for automating our operational environments.
 
-## Office Locations
+## Office locations
 
 We have none.
 

--- a/company-profiles/doist.md
+++ b/company-profiles/doist.md
@@ -24,7 +24,7 @@ Worldwide
 
 Android, iOS/OS X, Windows, Python, Django, Ruby on Rails, Javascript, HTML, CSS, CoffeeScript, React, MYSQL, Redis, GIT, Wordpress, C#, C++
 
-## Office Locations
+## Office locations
 
 R&D office in Porto, Portugal
 

--- a/company-profiles/dramafever.md
+++ b/company-profiles/dramafever.md
@@ -18,7 +18,7 @@ Remote friendly! (We use Slack, GitHub, etc.)
 
 Python, Golang, AngularJS, AWS
 
-## Office Locations
+## Office locations
 
 New York, NY & Philadelphia, PA
 

--- a/company-profiles/dronedeploy.md
+++ b/company-profiles/dronedeploy.md
@@ -18,7 +18,7 @@ You're expected to maintain a regular day-to-day schedule and be in the 'office'
 
 JavaScript, TypeScript, Cordova, iOS, Android, Angular2, Python
 
-## Office Locations
+## Office locations
 
 San Francisco, USA
 

--- a/company-profiles/edgar.md
+++ b/company-profiles/edgar.md
@@ -25,7 +25,7 @@ US and Canada
 
 Wordpress + Ruby on Rails (based on [careers page](http://meetedgar.com/careers/)).
 
-## Office Locations
+## Office locations
 
 We don't even HAVE a headquarters, unless you count our secret undersea laboratory.
 

--- a/company-profiles/edify.md
+++ b/company-profiles/edify.md
@@ -22,7 +22,7 @@ Costa Rica, US, Anywhere.
 
 Java, PHP, Ruby, JavaScript, Go, and anything that solves our client's needs.
 
-## Office Locations
+## Office locations
 
 - Alajuela, Costa Rica.
 - Atlanta, Georgia, US.

--- a/company-profiles/elastic.md
+++ b/company-profiles/elastic.md
@@ -25,7 +25,7 @@ We have employees in all around the world.
 - Ruby: Logstash
 - APIs: Perl, Python, Ruby, Golang ...
 
-## Office Locations
+## Office locations
 
 - San Francisco, CA
 - Amsterdam

--- a/company-profiles/envato.md
+++ b/company-profiles/envato.md
@@ -22,7 +22,7 @@ Envato is a fast growing company with headquarters in Melbourne.
 
 ## Company technologies
 
-## Office Locations
+## Office locations
 
 Headquarters in Melbourne, Australia. Team located around the world.
 

--- a/company-profiles/etsy.md
+++ b/company-profiles/etsy.md
@@ -22,7 +22,7 @@ Worldwide
 
 PHP, Postgres, Solr, Ruby, Hadoop, Go, JavaScript, CSS, Chef
 
-## Office Locations
+## Office locations
 
 Brooklyn, NY
 

--- a/company-profiles/evil-martians.md
+++ b/company-profiles/evil-martians.md
@@ -26,7 +26,7 @@ All stuff located all over the world
 
 Ruby on Rails, Ruby, Erlang, Scala, Go, Postgresql, Chef, React, Redux, Node.js
 
-## Office Locations
+## Office locations
 
 6 Chaplygina St, Moscow, Russia, 105062
 

--- a/company-profiles/example.md
+++ b/company-profiles/example.md
@@ -20,7 +20,7 @@ Is your company open to US-based remote employees only? Other countries? Worldwi
 
 Insert some of the technologies used in your company here.
 
-## Office Locations
+## Office locations
 
 Insert your physical office locations here.
 

--- a/company-profiles/eyeo.md
+++ b/company-profiles/eyeo.md
@@ -24,7 +24,7 @@ It doesn't matter where our team members are located, as long as they are passio
 
 JavaScript, Python, HTML, CSS, XUL, Java (Android), C++, Objective-C
 
-## Office Locations
+## Office locations
 
 The company is located in Cologne, Germany. We pay for coworking space elsewhere if remote workers want it.
 

--- a/company-profiles/findify.md
+++ b/company-profiles/findify.md
@@ -30,7 +30,7 @@ Worldwide, but mostly Europe
 
 You can check our stack on [StackShare](https://stackshare.io/findify)
 
-## Office Locations
+## Office locations
 
 Although, we don't have an official office, the company is registered in Stockholm, Sweden
 

--- a/company-profiles/fog-creek-software.md
+++ b/company-profiles/fog-creek-software.md
@@ -45,7 +45,7 @@ Worldwide
 - golang
 - ruby
 
-## Office Locations
+## Office locations
 
 New York, NY
 

--- a/company-profiles/formstack.md
+++ b/company-profiles/formstack.md
@@ -16,7 +16,7 @@ Formstack is a remote company, with employees in several states and countries. W
 
 Worldwide
 
-## Office Locations
+## Office locations
 
 8604 Allisonville Rd. Suite 300
 Indianapolis, IN 46250

--- a/company-profiles/formstack.md
+++ b/company-profiles/formstack.md
@@ -1,6 +1,6 @@
 # Formstack
 
-## Company Blurb
+## Company blurb
 
 Formstack's birthday is February 28, 2006. We started as one guy trying to provide a simple data capture solution. Since then, our product has evolved into a robust platform that helps users of all industries better engage with their customers and manage data. Formstack is headquartered in Indianapolis, Indiana, but our 500,000+ users live and work all over the world.
 
@@ -8,7 +8,7 @@ Formstack's birthday is February 28, 2006. We started as one guy trying to provi
 
 60 staff and growing!
 
-## Remote Status
+## Remote status
 
 Formstack is a remote company, with employees in several states and countries. While, yes, this means 'stackers can work at home in their PJs, it also means we've developed a unique culture that thrives on transparency, communication, and fun. We know how to work hard and play hard from wherever we feel most productive - whether that's on a living room couch, in the Formstack office, or on a beach in Thailand.
 
@@ -21,6 +21,6 @@ Worldwide
 8604 Allisonville Rd. Suite 300
 Indianapolis, IN 46250
 
-## How to Apply
+## How to apply
 
 [Formstack Careers](https://www.formstack.com/careers)

--- a/company-profiles/freeagent.md
+++ b/company-profiles/freeagent.md
@@ -18,7 +18,7 @@ Scotland, UK based company, remote worldwide
 ## Company technologies
 
 
-## Office Locations
+## Office locations
 
 FreeAgent
 One Edinburgh Quay

--- a/company-profiles/fuel-made.md
+++ b/company-profiles/fuel-made.md
@@ -22,7 +22,7 @@ Our positions require you to reside in western North America (Pacific or Mountai
 
 Primarily front end: (HTML, CSS, JS), as well as Liquid. Some modest backend stuff, bring your favorite backend stack with you.
 
-## Office Locations
+## Office locations
 
 No office! Well, except your office. But that's just for you. We don't bother you there.
 

--- a/company-profiles/full-fabric.md
+++ b/company-profiles/full-fabric.md
@@ -24,7 +24,7 @@ Europe
 - Coffeescript
 - Sass
 
-## Office Locations
+## Office locations
 
 London, UK
 

--- a/company-profiles/gaggle.md
+++ b/company-profiles/gaggle.md
@@ -25,7 +25,7 @@ USA
 - Git
 - JIRA, Confluence, Stash
 
-## Office Locations
+## Office locations
 
 - Bloomington, IL
 

--- a/company-profiles/gigsalad.md
+++ b/company-profiles/gigsalad.md
@@ -27,7 +27,7 @@ We are primarily interested in hiring U.S. remote employees.
 - Git
 - NodeJS
 
-## Office Locations
+## Office locations
 
 - Springfield, MO
 - Wilmington, NC

--- a/company-profiles/github.md
+++ b/company-profiles/github.md
@@ -26,7 +26,7 @@ Worldwide - We have employees in almost every time zone in the world! From San F
 - Sass
 - Git
 
-## Office Locations
+## Office locations
 
 - San Francisco, CA
 - Boulder, CO

--- a/company-profiles/gitprime.md
+++ b/company-profiles/gitprime.md
@@ -22,7 +22,7 @@ world, regardless of location.
 
 Python, Django, JavaScript, Angular, D3.js
 
-## Office Locations
+## Office locations
 
 Colorado, USA
 

--- a/company-profiles/gorman-health-group.md
+++ b/company-profiles/gorman-health-group.md
@@ -26,7 +26,7 @@ While we don't take new dependencies lightly, we do aggressively scout for new t
 
 That said, we do standardize when and where it makes sense. So far that's meant: Gitlab, Ubuntu, Vagrant, Salt, Docker, Ruby on Rails, JavaScript (Coffeescript), CSS (Stylus, LESS, Sass), HTML (Haml), Bash, some C#.NET MVC, and the typical myriad browser libraries including but not limited to `{jQuery, Bootstrap, Underscore, Backbone, Moment, Chart, Modernizr}.js`
 
-## Office Locations
+## Office locations
 
 Meatspace headquarters are allegedly in Washington, DC. Many of us have never ventured out to confirm this rumor, and those who have can't be trusted.
 

--- a/company-profiles/gridium.md
+++ b/company-profiles/gridium.md
@@ -33,7 +33,7 @@ About a third of us are in the Bay area, but we have several other US locales re
 * AWS
 * Postgres, Redis, etc.
 
-## Office Locations
+## Office locations
 
 There is no office. Work from where you work best.
 

--- a/company-profiles/grubhub.md
+++ b/company-profiles/grubhub.md
@@ -36,7 +36,7 @@ Our international employees are currently directly contracted.
 - Javascript (Angular2, react)
 - Git
 
-## Office Locations
+## Office locations
 
 - Chicago, IL - Headquarters
 - New York City, NY - Secondary main office

--- a/company-profiles/gruntwork.md
+++ b/company-profiles/gruntwork.md
@@ -32,7 +32,7 @@ Worldwide.
 
 The main technologies we use include [Terraform](https://www.terraform.io/), [Go](https://golang.org/), [Docker](https://www.docker.com/), [Packer](https://www.packer.io/), and [AWS](http://aws.amazon.com). We also spend a lot of time working on [open source](https://github.com/gruntwork-io/), [doing talks](http://www.ybrikman.com/writing/2016/03/31/infrastructure-as-code-microservices-aws-docker-terraform-ecs/), and writing [blog posts](https://blog.gruntwork.io/) and [books](http://www.terraformupandrunning.com/).
 
-## Office Locations
+## Office locations
 
 No offices. Feel free to work out of a co-working space, a coffee shop, your home, or anywhere else you're comfortable and productive.
 

--- a/company-profiles/hack-reactor-remote.md
+++ b/company-profiles/hack-reactor-remote.md
@@ -36,7 +36,7 @@ Currently, our full-time staff is based entirely in the United States.
 
 Asana, GitHub, Google Drive, Slack, Zoom
 
-## Office Locations
+## Office locations
 
 944 Market St, San Francisco, CA 94102
 

--- a/company-profiles/hanzo.md
+++ b/company-profiles/hanzo.md
@@ -24,7 +24,7 @@ Dev team is UK/EU, Sales&OPS are US/UK
 
 AWS, Python, Distributed systems, Ansible.
 
-## Office Locations
+## Office locations
 
 Leeds, Philadelphia.
 

--- a/company-profiles/happy-bear-software.md
+++ b/company-profiles/happy-bear-software.md
@@ -20,7 +20,7 @@ Worldwide
 
 Ruby, Rails, Sinatra, Javascript, Angular.js, Backbone.js, Git, Github, Slack, Trello.
 
-## Office Locations
+## Office locations
 
 We don't have any physical office but you're always invited to share a coworking space or coffee shop with one (or more) of us!
 

--- a/company-profiles/harvest.md
+++ b/company-profiles/harvest.md
@@ -24,7 +24,7 @@ Worldwide
 
 Docker, Chef,  Ansible, Ruby, AWS & Rackspace Cloud, MySQL, Nginx, Graphite, StatsD, Sensu, Git, Redis
 
-## Office Locations
+## Office locations
 
 [Harvest, 16 W 22nd St, 8th Floor New York, NY 10010](https://www.google.com/maps/place/16+W+22nd+St,+New+York,+NY+10010/@40.7412079,-73.9934994,17z/data=!3m1!4b1!4m2!3m1!1s0x89c259a386c20bd5:0x6da26b75635d4e84?hl=en)
 

--- a/company-profiles/he-labs.md
+++ b/company-profiles/he-labs.md
@@ -20,7 +20,7 @@ Worldwide
 
 Ruby, Clojure, Elixir, JavaScript, HTML5, CSS3, Postgres, Heroku, AWS, GCE, Docker, Kubernetes
 
-## Office Locations
+## Office locations
 
 Rio de Janeiro, BRA
 

--- a/company-profiles/heap.md
+++ b/company-profiles/heap.md
@@ -22,7 +22,7 @@ We hire engineers worldwide.
 
 Our app-layer stack is TypeScript, Backbone, Marionette, Node.js, Redis, and PostgreSQL. Under the hood, Heap is powered by CoffeeScript, Scala, ZooKeeper, Kafka, Akka, and CitusDB.
 
-## Office Locations
+## Office locations
 
 San Francisco, CA, USA
 

--- a/company-profiles/hireology.md
+++ b/company-profiles/hireology.md
@@ -29,7 +29,7 @@ Remote position are open to any U.S. citizen whose permanent address is in the U
 
 Ruby on Rails, React, PostgreSQL, SASS
 
-## Office Locations
+## Office locations
 
 Chicago, IL
 

--- a/company-profiles/honeycomb.md
+++ b/company-profiles/honeycomb.md
@@ -27,7 +27,7 @@ We also love Ansible, AWS/Azure, Git, Postgres, Redis, Github, Slack, and Trello
 
 Europe
 
-## Office Locations
+## Office locations
 
 * London, UK
 * Frankfurt, DE

--- a/company-profiles/hudl.md
+++ b/company-profiles/hudl.md
@@ -21,7 +21,7 @@ US and UK based employees.
 
 Hudl keep a GitHub pages site [hudl.github.io](http://hudl.github.io/) showing their Open Source projects and technology
 
-## Office Locations
+## Office locations
 
 We’re headquartered in the Haymarket District of Lincoln, Nebraska.
 

--- a/company-profiles/hugo.md
+++ b/company-profiles/hugo.md
@@ -17,7 +17,7 @@ Please check our stack on Stackshare here:
 Hugo: https://stackshare.io/hugo-events
 Quriobot: https://stackshare.io/quriobot/quriobot
 
-## Office Locations
+## Office locations
 
 Hugo office is located in [Amsterdam](https://www.google.co.uk/maps/place/Keienbergweg+97,+1101+GG+Amsterdam,+Netherlands)
 

--- a/company-profiles/human-made.md
+++ b/company-profiles/human-made.md
@@ -22,7 +22,7 @@ Worldwide
 
 WordPress, PHP, Javascript, server technologies?
 
-## Office Locations
+## Office locations
 
 We have offices in the UK and Australia.
 

--- a/company-profiles/hyperion.md
+++ b/company-profiles/hyperion.md
@@ -20,7 +20,7 @@ South Africa (some positions are open to the rest of Africa)
 
 Must be proficient in at least one modern programming language (eg Java/Python/C++/C#)
 
-## Office Locations
+## Office locations
 
 - 6 Cotswold Drive, Westville, __Durban, South Africa__
 - Office 4/5, Bandwidth Barn, The Woodstock Exchange, 66 Albert Road, Woodstock, __Cape Town, South Africa__

--- a/company-profiles/hypothesis.md
+++ b/company-profiles/hypothesis.md
@@ -20,7 +20,7 @@ Most of us are in the US and Europe, but we're open to consider other locations 
 
 Python, Javascript, some Angular, so much more!
 
-## Office Locations
+## Office locations
 
 We have a small co-working space in SF and another in Berlin.
 

--- a/company-profiles/incsub.md
+++ b/company-profiles/incsub.md
@@ -31,7 +31,7 @@ We have employees in many different countries around Europe, America and Asia, s
 - Vagrant
 - Git
 
-## Office Locations
+## Office locations
 
 - Melbourne, Australia
 

--- a/company-profiles/inquicker.md
+++ b/company-profiles/inquicker.md
@@ -38,7 +38,7 @@ US and Canada:
 * Docker + Kubernetes
 * Clojure
 
-## Office Locations
+## Office locations
 [Nashville, TN](https://goo.gl/maps/8xGfZPnaq4B2) and hopefully Portland, soon.
 
 ## How to apply

--- a/company-profiles/interactive-intelligence.md
+++ b/company-profiles/interactive-intelligence.md
@@ -16,7 +16,7 @@ We don't typically hire remotes. Usually people whom have worked with the compan
 
 Remotes are preferred to be on New York time or similar, as our main offices are on New York time, but there are various remotes throughout the globe.
 
-## Office Locations
+## Office locations
 
 Main developer locations: Indianapolis, IN; Raleigh, NC;
 We also have other various worldwide business office locations.

--- a/company-profiles/intercom.md
+++ b/company-profiles/intercom.md
@@ -20,7 +20,7 @@ Dependent on position.
 
 Ruby, Ruby on Rails, Ember.js, MongoDB, MySQL, Redis, Pusher, nginx, Sinatra, Sidekiq, and lots more
 
-## Office Locations
+## Office locations
 
 SF: [55 2nd St, 4th Fl. San Francisco, CA 94105](https://www.google.co.uk/maps/place/Intercom/@37.788802,-122.400318,15z/data=!4m2!3m1!1s0x0:0x305f890d78b83852?hl=en)
 Dublin: [2nd Floor, Stephen Court, 18-21 St Stephen's Green, Dublin 2, Ireland](https://www.google.co.uk/maps/place/Intercom/@53.339371,-6.259684,17z/data=!3m1!4b1!4m2!3m1!1s0x48670e9fe8e64383:0x7a290f5513b3aacd?hl=en)

--- a/company-profiles/iwantmyname.md
+++ b/company-profiles/iwantmyname.md
@@ -23,7 +23,7 @@ Worldwide - iwantmyname has been remote since day one.
 
 We're currently using modern Perl, Erlang, Python, node, CouchDB, RabbitMQ, Kyoto Tycoon, Puppet, Vagrant, Docker and are looking at a whole lot of new toys to build the best possible experience for our customers.
 
-## Office Locations
+## Office locations
 
 167B Vivian St, Wellington 6011, NZ. [street view](https://www.google.com/maps/preview#!q=167+Vivian+St&data=!1m8!1m3!1d3!2d174.774182!3d-41.294553!2m2!1f233.46!2f102.15!4f75!2m4!1e1!2m2!1sCT-0ePfA5A3F3GKEoOX9sQ!2e0!4m15!2m14!1m13!1s0x6d38afd86ffac675%3A0xa1a853e42fca0b80!3m8!1m3!1d429156!2d-117.1089785!3d32.8245525!3m2!1i1024!2i768!4f13.1!4m2!3d-41.2946876!4d174.7740194&fid=5)
 

--- a/company-profiles/jackson-river.md
+++ b/company-profiles/jackson-river.md
@@ -20,7 +20,7 @@ Jackson River currently only has US-based employees.
 
 Apache, MySQL, PHP, Drupal, HTML, CSS, JavaScript.
 
-## Office Locations
+## Office locations
 
 Washington, DC.
 

--- a/company-profiles/jitbit.md
+++ b/company-profiles/jitbit.md
@@ -20,7 +20,7 @@ Worldwide
 
 C#, ASP.NET MVC, ASP.NET Core, Javascript, Angular, Typescript, Ionic, Python
 
-## Office Locations
+## Office locations
 
 We do not have an office - everyone chooses where they want to work from.
 

--- a/company-profiles/kiprosh.md
+++ b/company-profiles/kiprosh.md
@@ -65,7 +65,7 @@ Integration with Payment gateways like - Stripe, Authorize.Net, BrainTree, Charg
 Trello, Pivotal Tracker, AgileZen and Sprint.ly
 
 
-## Office Locations
+## Office locations
 
 - Mumbai, India (Headquarters)
 - Chicago, USA

--- a/company-profiles/kissmetrics.md
+++ b/company-profiles/kissmetrics.md
@@ -18,7 +18,7 @@ Primarily based out of San Francisco, but KissMetrics have a strong remote prese
 
 Javascript, React, jQuery, Backbone, Git, Distributed systems, PostgresSQL, MySQL, Key-Value Stores, R, Ruby, Python, etc.
 
-## Office Locations
+## Office locations
 
 Headquarters in San Francisco, USA.
 

--- a/company-profiles/knack.md
+++ b/company-profiles/knack.md
@@ -4,11 +4,7 @@
 
 Knack is the easiest way to build your own online database. With Knack anyone can build apps to access your data from anywhere, run reports and analytics, and share it with your users, employees, or customers. You can publish your apps to any website or blog.
 
-## Who we are
-
 We've spent over 3 years thinking about online databases so you don't have to. Our founders have decades of experience building thousands of web applications and online databases. We've poured this experience into a product that is both easy to use but packed with the features you need.
-
-## Our mission
 
 Our mission is simple: to empower you to make the most of your data by easily building online databases and web apps.
 

--- a/company-profiles/kodify.md
+++ b/company-profiles/kodify.md
@@ -21,7 +21,7 @@ Company is based in Barcelona, Spain but you can work from everywhere
 
 NodeJS and JS. Not sure about the db's
 
-## Office Locations
+## Office locations
 
 Barcelona, Spain
 

--- a/company-profiles/laterpay.md
+++ b/company-profiles/laterpay.md
@@ -24,7 +24,7 @@ Europe, US, Brazil, Canada. Most of our people are in Europe, so we try to ensur
 
 Python, Postgres, JS, React.
 
-## Office Locations
+## Office locations
 
 Munich (Germany), NY (US)
 

--- a/company-profiles/let-s-encrypt.md
+++ b/company-profiles/let-s-encrypt.md
@@ -20,7 +20,7 @@ Is your company open to US-based remote employees only? Other countries? Worldwi
 
 Insert some of the technologies used in your company here.
 
-## Office Locations
+## Office locations
 
 Insert your physical office locations here.
 

--- a/company-profiles/litmus.md
+++ b/company-profiles/litmus.md
@@ -20,7 +20,7 @@ We have offices in London, Boston, and San Francisco, but many of our employees 
 
 Ruby on Rails, .NET, AWS
 
-## Office Locations
+## Office locations
 
 Boston, London, San Francisco, and around the world.
 

--- a/company-profiles/loadsys.md
+++ b/company-profiles/loadsys.md
@@ -4,6 +4,14 @@
 
 [Loadsys Web Strategies](https://www.loadsys.com.com) is a web development company that specializes in custom web application development and WordPress websites. Our process includes requirements determination, wireframing, product development, testing / QA, deployment and ongoing support. We are a team of 7 full-time developers, all located in the United States.
 
+Our benefits include:
+
+-   Competitive Pay
+-   4 weeks of vacation
+-   401k options
+-   Cutting edge learning environment
+-   2 company retreats each year
+
 ## Company size
 
 7 Developers
@@ -12,7 +20,7 @@
 
 Our team is fully virtual with all members located in the United States.  As we formed in the Chicagoland area, we have more members located in the Midwest region, but also have one in Vegas and North Carolina.
 
-## Company technologies and requirements
+## Company technologies
 
 -   CakePHP (supporting v2.X and 3.X and upgrades from 1.3)
 -   Ember.js
@@ -20,13 +28,6 @@ Our team is fully virtual with all members located in the United States.  As we 
 -   Vagrant
 -   HTML, CSS, and Javascript
 -   Wordpress
-
-## Benefits
--   Competitive Pay
--   4 weeks of vacation
--   401k options
--   Cutting edge learning environment
--   2 company retreats each year
 
 ## How to apply
 

--- a/company-profiles/localistico.md
+++ b/company-profiles/localistico.md
@@ -22,7 +22,7 @@ Localistico is focused in UK and Spain currently, but you can work from wherever
 
 Localistico is based on Ruby on Rails, with some Go components. Data storage is PostgreSQL, Redis/resque and ElasticSearch. Our frontend is a web app in Ember.js. Our whole deployment is cloud based with Codeship+Heroku. We use Github as code repository and issues platform.
 
-## Office Locations
+## Office locations
 
 We have offices in London and Madrid.
 

--- a/company-profiles/lullabot.md
+++ b/company-profiles/lullabot.md
@@ -29,7 +29,7 @@ At Lullabot our virtual employees are our physical employees. We do not have a c
 - Phone Gap
 - Titanium
 
-## Office Locations
+## Office locations
 
 Completely distributed!
 

--- a/company-profiles/manifold.md
+++ b/company-profiles/manifold.md
@@ -30,7 +30,7 @@ UTC-9 to UTC+1. Time shifting at the boundaries is typically necessary.
 - Git and Github
 
 
-## Office Locations
+## Office locations
 
 - HQ in Halifax, NS, Canada
 - Office in San Francisco

--- a/company-profiles/mapbox.md
+++ b/company-profiles/mapbox.md
@@ -50,7 +50,7 @@ The vast majority of Mapbox’s data is in the open. Large sources include [Open
 
 We also work extensively with proprietary sets of data that we buy: we legally can’t open these. Nor do we release heavily processed data. Processing data and delivering the final products has obvious and real costs: server infrastructure and bandwidth, as well as labor. Our ability to distill meaning out of raw material is a core part of our product.
 
-## Office Locations
+## Office locations
 
 We are located in DC, SF, Ayacucho, Bangalore and Berlin.
 

--- a/company-profiles/marsbased.md
+++ b/company-profiles/marsbased.md
@@ -23,7 +23,7 @@ We're just hiring EU-residents with a working permit. Freelancers willing to do 
 
 Ruby, Rails, Sinatra, Node.js, Angular, React, Vue.js.
 
-## Office Locations
+## Office locations
 
 No physical offices, but we're from Barcelona.
 

--- a/company-profiles/mediacurrent.md
+++ b/company-profiles/mediacurrent.md
@@ -20,7 +20,7 @@ US-based employees
 
 Drupal
 
-## Office Locations
+## Office locations
 
 3180 North Point Parkway Suite 208, Alpharetta, Ga 30005
 

--- a/company-profiles/mixmax.md
+++ b/company-profiles/mixmax.md
@@ -26,7 +26,7 @@ Anywhere in the world, as long as you're willing to overlap at least 4hrs a day 
 
 Current stack is Node, Express, Meteor, Redis, Mongo, AWS, Electron.
 
-## Office Locations
+## Office locations
 
 95 Federal St, San Francisco, CA
 

--- a/company-profiles/mtc.md
+++ b/company-profiles/mtc.md
@@ -26,7 +26,7 @@ Front-end uses LESS/jQuery/VueJS.
 
 We also develop applications for iOS and Android with Swift/Java.
 
-## Office Locations
+## Office locations
 
 * Dundee, Scotland, UK
 * Edinburgh, Scotland, UK

--- a/company-profiles/muck-rack.md
+++ b/company-profiles/muck-rack.md
@@ -30,7 +30,7 @@ Worldwide!
 - Sass
 - Backbone, ES6, Webpack
 
-## Office Locations
+## Office locations
 
 Sawhorse Media
 588 Broadway Suite #503

--- a/company-profiles/netsparker.md
+++ b/company-profiles/netsparker.md
@@ -26,7 +26,7 @@ Worldwide
 
 .NET Framework, Winforms
 
-## Office Locations
+## Office locations
 
 - London, UK
 - USA

--- a/company-profiles/nettl-edinburgh.md
+++ b/company-profiles/nettl-edinburgh.md
@@ -24,7 +24,7 @@ Apache
 PHP
 MySQL
 
-## Office Locations
+## Office locations
 
 Edinburgh, Scotland, UK
 Greenock, Glasgow, UK

--- a/company-profiles/new-context.md
+++ b/company-profiles/new-context.md
@@ -24,7 +24,7 @@ Customers are mostly based in the US.
 
 If there's a tool common in solving DevOps problems, we've probably got someone proficient in it. Our most common tool of choice however is Chef.
 
-## Office Locations
+## Office locations
 
 Main office in downtown San Francisco
 

--- a/company-profiles/nodesource.md
+++ b/company-profiles/nodesource.md
@@ -29,7 +29,7 @@ Our employees are located worldwide - in Australia, United Kingom, Colombia, Sou
 * AWS
 * C++
 
-## Office Locations
+## Office locations
 
 - San Francisco
 - Remote

--- a/company-profiles/noredink.md
+++ b/company-profiles/noredink.md
@@ -25,7 +25,7 @@ Pacific Time (PST) to Central European Time (CET)
 * JavaScript
 * Elm
 
-## Office Locations
+## Office locations
 
 Headquarters in San Francisco, CA.
 

--- a/company-profiles/novoda.md
+++ b/company-profiles/novoda.md
@@ -22,7 +22,7 @@ Europe
 
 Android, iOS, and anything mobile.
 
-## Office Locations
+## Office locations
 
 We have offices in Barcelona, Berlin, Liverpool, and London, with remote workers in Europe.
 

--- a/company-profiles/oddball.md
+++ b/company-profiles/oddball.md
@@ -24,7 +24,7 @@ US based only we work with the government and can't flex on this
 * golang
 * ansible/terraform
 
-## Office Locations
+## Office locations
 We have a small coworking space in sunny Los Angeles, CA, but all of the companyy is remote.
 
 

--- a/company-profiles/olark.md
+++ b/company-profiles/olark.md
@@ -20,7 +20,7 @@ UTC-8 (Pacific) to UTC+1 (Central Europe)
 
 Python, node.js, ECMAScript 5/6, CoffeeScript, Ruby/Rails, Go, redis, SQL
 
-## Office Locations
+## Office locations
 
 San Francisco, CA and Ann Arbor, MI
 

--- a/company-profiles/olo.md
+++ b/company-profiles/olo.md
@@ -26,7 +26,7 @@ USA
 
 Primarily .NET stack. C#, F#, SQL, Elasticsearch, node.js, Ember, React, AWS.
 
-## Office Locations
+## Office locations
 
 NYC
 

--- a/company-profiles/omniti.md
+++ b/company-profiles/omniti.md
@@ -34,7 +34,7 @@ OmniTI is open to hiring worldwide, though some projects may prefer team members
 - Ansible, Chef
 - Git, Subversion
 
-## Office Locations
+## Office locations
 
 - Fulton, MD
 - New York City, NY

--- a/company-profiles/pagerduty.md
+++ b/company-profiles/pagerduty.md
@@ -25,7 +25,7 @@ Some of what we use:
 - MySQL / Percona Xtradb Cluster, Cassandra, Elasticsearch, Kafka, Zookeeper
 - View more on [StackShare.io](https://stackshare.io/pagerduty/pagerduty)
 
-## Office Locations
+## Office locations
 
 - San Francisco, US
 - Toronto, CA

--- a/company-profiles/paktor.md
+++ b/company-profiles/paktor.md
@@ -22,7 +22,7 @@ Open to all countries.
 
 Java, Javascript, Node.js, Agile, Git, Angular.js, mySQL, Python, Java Spring MV, Spark, AWS.
 
-## Office Locations
+## Office locations
 
 Seoul, Taipei, Hong Kong, Kuala Lumpur, with headquarters in Singapore.
 

--- a/company-profiles/palantir-net.md
+++ b/company-profiles/palantir-net.md
@@ -20,7 +20,7 @@ US only.
 
 - Drupal
 
-## Office Locations
+## Office locations
 
 **Remote Outpost**
 

--- a/company-profiles/park-assist.md
+++ b/company-profiles/park-assist.md
@@ -44,7 +44,7 @@ C++, OpenCV, Ruby, Sinatra, CircleCI, GitHub, Ruby on Rails, JRuby, PostgreSQL, 
 Worldwide
 
 
-## Office Locations
+## Office locations
 
 * Headquarters: New York City, New York, USA
 * Beesd, Gelderland, The Netherlands

--- a/company-profiles/payfully.md
+++ b/company-profiles/payfully.md
@@ -24,7 +24,7 @@ Payfully employs people worldwide
 
 MongoDB, Node.js, Software Architecture, Information Architecture, AWS/EC2/ELB/S3/DynamoDB, TypeScript.
 
-## Office Locations
+## Office locations
 
 HQ at New York city, Medellin-Colombia, Minsk-Belarus, Vietnam.
 

--- a/company-profiles/percona.md
+++ b/company-profiles/percona.md
@@ -23,7 +23,7 @@ See:
 - https://github.com/percona
 - https://www.percona.com/software
 
-## Office Locations
+## Office locations
 
 HQ is in North Carolina, USA.
 

--- a/company-profiles/platform-sh.md
+++ b/company-profiles/platform-sh.md
@@ -53,7 +53,7 @@ but we hire on competency alone, not on time-zone affiliation.
 * Angular.js
 * LXC/Zookeeper/Kafka/Riemann/Ceph/Influxdb
 
-## Office Locations
+## Office locations
 [Paris Center](https://www.google.fr/maps/place/Commerce+Guys/@48.8706972,2.3444958,17z/data=!4m7!1m4!3m3!1s0x47e66e1611f61889:0x6559e547fc0c89ef!2sCommerce+Guys!3b1!3m1!1s0x47e66e1611f61889:0x6559e547fc0c89ef)
 
 ## How to apply

--- a/company-profiles/prezly.md
+++ b/company-profiles/prezly.md
@@ -15,10 +15,6 @@ Agencies using Prezly: Edelman, Grayling, Ketchum, Ogilvy, Porter Novelli, TBWA,
 
 0-10 Employees
 
-## Looking for
-
-We’re looking for curious, hard-working people to join our team, to help us do the best work of our lives. Together we’ll create products and services that help inspiring brands share their stories with the world.
-
 ## Remote status
 
 Our philosophy is collaboration-focused, remote-friendly, and flexible. We care deeply about supporting the growth of all our employees and making sure they feel professionally fulfilled.
@@ -42,5 +38,7 @@ Worldwide
 The Prezly team is spread across seven different cities around the world. Our office is in Leuven, Belgium, but everyone at Prezly is free to live and work wherever they want.
 
 ## How to apply
+
+We’re looking for curious, hard-working people to join our team, to help us do the best work of our lives. Together we’ll create products and services that help inspiring brands share their stories with the world.
 
 [Prezly careers](https://www.prezly.com/careers) or [jobs@prezly.com](mailto:jobs@prezly.com)

--- a/company-profiles/puppet.md
+++ b/company-profiles/puppet.md
@@ -32,7 +32,7 @@ US, APAC, and EMEA.
 
 Puppet, Ruby, Clojure, and whole lot more.
 
-## Office Locations
+## Office locations
 
 We are located in the Block 300 Building in downtown Portland, one block from
 the Tom McCall Waterfront Park and a multitude of food carts! We also have

--- a/company-profiles/rackspace.md
+++ b/company-profiles/rackspace.md
@@ -33,7 +33,7 @@ Worldwide
 Varies on the engineering team and project, but usually Python, OpenStack,
 orchestration/deployment, virtualization, Linux/Windows, testing.
 
-## Office Locations
+## Office locations
 
 We have offices in the following locations:
 

--- a/company-profiles/reactiveops.md
+++ b/company-profiles/reactiveops.md
@@ -30,7 +30,7 @@ US-only - we have many clients that require certain background checks to be perf
 * OpenVPN
 * StackStorm
 
-## Office Locations
+## Office locations
 
 Wherever you're working. :)
 

--- a/company-profiles/recharge.md
+++ b/company-profiles/recharge.md
@@ -24,7 +24,7 @@ Worldwide
 
 Javascript, CSS, MySQL, HTML, Python, Coffee, and Magic
 
-## Office Locations
+## Office locations
 
 Santa Monica, CA
 

--- a/company-profiles/red-hat.md
+++ b/company-profiles/red-hat.md
@@ -25,7 +25,7 @@ Worldwide
 - C, C++, Java, Python, Ruby, ...
 - and [many, many more](http://community.redhat.com/software/)
 
-## Office Locations
+## Office locations
 
 - Raleigh, NC
 - Westford, MA

--- a/company-profiles/rtcamp-solutions.md
+++ b/company-profiles/rtcamp-solutions.md
@@ -16,7 +16,7 @@ Our Team is spread all across India.
 - WordPress
 - NGINX
 
-##  Office Locations
+##  Office locations
 Pune, India
 
 ## How to apply

--- a/company-profiles/sensu.md
+++ b/company-profiles/sensu.md
@@ -22,7 +22,7 @@ Ruby, Go, JavaScript, React, Etcd, Docker, Kubernetes, Puppet, Chef, Graphite, I
 
 Sensu is an open source project, familiarity with GitHub and experience with other open source projects is a bonus, but in no way required.
 
-## Office Locations
+## Office locations
 
 As Sensu is a fully distributed, remote-first company, we currently have no physical locations. However, we do have a number of employees in Portland who occasionally share a coworking space.
 

--- a/company-profiles/server-density.md
+++ b/company-profiles/server-density.md
@@ -20,7 +20,7 @@ Europe
 
 Python, MongoDB, Nginx, Linux, React, Backbone, Coffeescript
 
-## Office Locations
+## Office locations
 
 London
 

--- a/company-profiles/simplabs.md
+++ b/company-profiles/simplabs.md
@@ -34,7 +34,7 @@ We support working remotely from Europe and the Americas.
 
 Emberjs, Elixir/Phoenix, Ruby/Rails
 
-## Office Locations
+## Office locations
 
 simplabs GmbH
 Claude-Lorrain-Str. 7

--- a/company-profiles/simple.md
+++ b/company-profiles/simple.md
@@ -23,7 +23,7 @@ Anywhere in the United States
 Scala, Java, JavaScript, Ember, Ruby, Rails, Go, HTML, CSS, JQuery, Clojure, SQL, Postgres, Swift
 
 
-## Office Locations
+## Office locations
 
 Portland, OR
 

--- a/company-profiles/simpletexting.md
+++ b/company-profiles/simpletexting.md
@@ -28,7 +28,7 @@ Remote positions are available globally.
 - JavaScript
 - Node.JS
 
-## Office Locations
+## Office locations
 
 - Miami, FL, USA (Headquarters)
 

--- a/company-profiles/six-to-start.md
+++ b/company-profiles/six-to-start.md
@@ -22,7 +22,7 @@ Worldwide
 
 - JavaScript, Python, Swift, Java
 
-## Office Locations
+## Office locations
 
 - London, UK
 

--- a/company-profiles/skillcrush.md
+++ b/company-profiles/skillcrush.md
@@ -25,7 +25,7 @@ Skillcrush is located in the US but we are open to candidates from all around th
 
 Wordpress, Ruby, Rails, JavaScript, jQuery, HTML, CSS
 
-## Office Locations
+## Office locations
 
 Headquarters are in New York but everyone is 100% remote. 
 

--- a/company-profiles/spoqa.md
+++ b/company-profiles/spoqa.md
@@ -20,7 +20,7 @@ We have Seoul, Busan, and Tokyo office but if you want to work remotely, it does
 
 Python, Swift, Kotlin
 
-## Office Locations
+## Office locations
 
 ### Seoul
 420, Teheran-ro,

--- a/company-profiles/spreedly.md
+++ b/company-profiles/spreedly.md
@@ -22,7 +22,7 @@ As of the summer of 2016, we're focused on US-friendly timezones - you should be
 
 We have a lot of Ruby, two very well-written and up-to-date Rails apps, and are starting most greenfields development in Elixir.
 
-## Office Locations
+## Office locations
 
 Durham, NC, USA
 

--- a/company-profiles/stack-exchange.md
+++ b/company-profiles/stack-exchange.md
@@ -23,7 +23,7 @@ Worldwide - "Work Where You Want"
 
 The tools and technologies used to build the Stack Exchange network are listed in a questions on [meta.stackexchange.com](http://meta.stackexchange.com/questions/10369/which-tools-and-technologies-are-used-to-build-the-stack-exchange-network)
 
-## Office Locations
+## Office locations
 
 We have offices in New York, London, and Denver.
 

--- a/company-profiles/stairlin.md
+++ b/company-profiles/stairlin.md
@@ -31,7 +31,7 @@ Worldwide
  - Couchbase, InfluxDB, Consul
  - Docker, Swarm
 
-## Office Locations
+## Office locations
 
 Stairlin has an office in Zürich (Switzerland) and Lausanne (Switzerland) - GMT+2
 

--- a/company-profiles/status.md
+++ b/company-profiles/status.md
@@ -16,7 +16,7 @@ Everyone at Status works from a location of their choosing - and we all meet up 
 
 Worldwide
 
-## Office Locations
+## Office locations
 
 * Zug, Switzerland
 

--- a/company-profiles/stencil.md
+++ b/company-profiles/stencil.md
@@ -20,7 +20,7 @@ We'd prefer continental US and Canadian employees in Eastern Standard Time, but 
 
 Javascript, Canvas, HTML5, AWS
 
-## Office Locations
+## Office locations
 
 Toronto, Canada
 

--- a/company-profiles/stripe.md
+++ b/company-profiles/stripe.md
@@ -20,7 +20,7 @@ Stripe support remote working, according to [Cristina Cordova - BD @ Stripe](htt
 
 Ruby, CoffeeScript, Backbone.js, Sinatra, PostgreSQL, hadoop, redis, AWS
 
-## Office Locations
+## Office locations
 
 Headquarters are:
 3180 18th St

--- a/company-profiles/studysoup.md
+++ b/company-profiles/studysoup.md
@@ -36,7 +36,7 @@ Zoho
 Stripe
 SendWithUs
 
-## Office Locations
+## Office locations
 
 1381 9th Ave, San Francisco, CA 94122
 

--- a/company-profiles/taskade.md
+++ b/company-profiles/taskade.md
@@ -20,7 +20,7 @@ Worldwide
 
 React, Postgres, Redis, JavaScript, CSS
 
-## Office Locations
+## Office locations
 
 Astoria, NY
 

--- a/company-profiles/taxjar.md
+++ b/company-profiles/taxjar.md
@@ -20,7 +20,7 @@ TaxJar is currently hiring developers in the United States.
 
 Ruby, Rails, Elixir, Phoenix, PostgreSQL, Redis, Vue.js, Heroku, AWS
 
-## Office Locations
+## Office locations
 
 Headquartered in Boston, MA
 

--- a/company-profiles/the-ghost-foundation.md
+++ b/company-profiles/the-ghost-foundation.md
@@ -30,7 +30,7 @@ Worldwide (See above)
 
 Ember.js, node.js, Grunt,
 
-## Office Locations
+## Office locations
 
 No physical office.
 

--- a/company-profiles/the-grid.md
+++ b/company-profiles/the-grid.md
@@ -18,7 +18,7 @@ Worldwide
 ## Company technologies
 React, Inferno, iOS, Android
 
-## Office Locations
+## Office locations
 SF and Berlin
 
 ## How to apply

--- a/company-profiles/the-scale-factory.md
+++ b/company-profiles/the-scale-factory.md
@@ -25,7 +25,7 @@ We work heavily with Amazon Web Services, Terraform and Puppet.  A lot of
 our internal tooling is in Ruby, and we work with customers across a range
 of languages and technology stacks.
 
-## Office Locations
+## Office locations
 
 We have an office on [Borough High Street, London, SE1
 1NP](https://www.google.co.uk/maps/place/The+Scale+Factory/@51.503708,-0.0933892,17z/data=!3m1!4b1!4m5!3m4!1s0x48760359ccd42b4b:0x6a97c8ef4c88c0a9!8m2!3d51.503708!4d-0.0912005)

--- a/company-profiles/the-wirecutter.md
+++ b/company-profiles/the-wirecutter.md
@@ -25,7 +25,7 @@ United States.
 
 (TODO)
 
-## Office Locations
+## Office locations
 
 New York City
 

--- a/company-profiles/thinkful.md
+++ b/company-profiles/thinkful.md
@@ -23,7 +23,7 @@ Worldwide! The US region has the majority of employees, but we have a presence i
 - Vue.js
 - Python
 
-## Office Locations
+## Office locations
 
 55 Prospect St, Brooklyn, NY 11201
 

--- a/company-profiles/timespot.md
+++ b/company-profiles/timespot.md
@@ -21,7 +21,7 @@ overlap with US business hours.
 
 React.js, Django, Postgres, Docker, Fabric.
 
-## Office Locations
+## Office locations
 
 No physical office location.
 

--- a/company-profiles/toggl.md
+++ b/company-profiles/toggl.md
@@ -20,7 +20,7 @@ Worldwide - Toggl don't hire on location
 
 Sass, CoffeeScript, jQuery, Underscore, Bower
 
-## Office Locations
+## Office locations
 
 No physical office
 

--- a/company-profiles/toptal.md
+++ b/company-profiles/toptal.md
@@ -25,7 +25,7 @@ Toptal employees are spread throughout the world.
 
 RoR, JavaScript, CoffeeScript, Sass, Haml, Slim, Underscore.js, Backbone.js, React.js, Google Closure, Cucumber, Waiter, PhantomJS,
 
-## Office Locations
+## Office locations
 
 Toptal are 100% remote.
 

--- a/company-profiles/transloadit.md
+++ b/company-profiles/transloadit.md
@@ -43,7 +43,7 @@ Work from anywhere in the world : )
 - Ubuntu
 - AWS
 
-## Office Locations
+## Office locations
 
 - Berlin, Germany
 - Amsterdam, The Netherlands

--- a/company-profiles/treehouse.md
+++ b/company-profiles/treehouse.md
@@ -16,7 +16,7 @@ Certain positions are remote friendly within the United States. Everyone gets th
 
 United States
 
-## Office Locations
+## Office locations
 
 * Portland, OR
 * Orlando, FL

--- a/company-profiles/udacity.md
+++ b/company-profiles/udacity.md
@@ -23,7 +23,7 @@ Worldwide
 
 Much like *where* we work, we believe *how* we work should be dictated by productivity and fit for the task at hand. Our team uses a number of technologies (React/GraphQL, Ruby on Rails, Go, Scala, Python, Angular, Java and Objective-C to name a few), but you're welcome to use whatever language/framework/dev environment will let you do your best work.
 
-## Office Locations
+## Office locations
 
 Our Main Office is in Mountain View, CA. We have additional offices in San Francisco and Shanghai, with more on the way.
 

--- a/company-profiles/ushahidi.md
+++ b/company-profiles/ushahidi.md
@@ -30,7 +30,7 @@ Worldwide - we have team members in many different countries and timezones.
 
 PHP, Javascript, AngularJS, Laravel, Nginx, MySQL, Ansible, Docker, Python, RabbitMQ.
 
-## Office Locations
+## Office locations
 
 We have an office in Nairobi, Kenya.
 

--- a/company-profiles/webikon.md
+++ b/company-profiles/webikon.md
@@ -32,7 +32,7 @@ We are company from Slovakia (EU).
 * Redis/Memcache
 * Solr
 
-## Office Locations
+## Office locations
 
 None; or everywhere!
 

--- a/company-profiles/wemake-services.md
+++ b/company-profiles/wemake-services.md
@@ -27,7 +27,7 @@ Our headquarter is in Moscow, Russia.
 Our main stack is `django` + `vue`. We also love `elixir`.
 [Here's](https://stackshare.io/kotenkov_a/wemake-services) our detailed stack.
 
-## Office Locations
+## Office locations
 
 We don't have any offices! It is awesome, isn't it?
 

--- a/company-profiles/wikimedia-foundation.md
+++ b/company-profiles/wikimedia-foundation.md
@@ -32,7 +32,7 @@ We are a global organization and welcome international applicants for positions 
 
 PHP, Varnish, Nginx, Hadoop, R, Java, and Bayesian Analysis, MariaDB, MySQL, NoSQL, Puppet
 
-## Office Locations
+## Office locations
 
 The Wikimedia Foundation's head office is in San Francisco
 

--- a/company-profiles/wildbit.md
+++ b/company-profiles/wildbit.md
@@ -20,7 +20,7 @@ Most of the team work out at the office in Old City, Philadelphia, and others sp
 
 Ruby on Rails, .NET MVC, RabbitMQ, MySQL, ElasticSearch, etc.
 
-## Office Locations
+## Office locations
 
 Headquarters in Philadelphia, USA.
 

--- a/company-profiles/wolfram.md
+++ b/company-profiles/wolfram.md
@@ -22,7 +22,7 @@ Over the past quarter of a century, Wolfram has established itself as a powerhou
 
 Insert some of the technologies used in your company here.
 
-## Office Locations
+## Office locations
 
 - London, UK
 - Champaign, United States

--- a/company-profiles/zapier.md
+++ b/company-profiles/zapier.md
@@ -51,7 +51,7 @@ Queues:
 - RabbitMQ
 - Kafka
 
-## Office Locations
+## Office locations
 
 **None**
 

--- a/company-profiles/zeit-io.md
+++ b/company-profiles/zeit-io.md
@@ -21,7 +21,7 @@ We have offices in Göttingen and Hamburg in Germany.
 
 Ruby, Rails, Node.js, Elixir, C/C++, PostgreSQL and more...
 
-## Office Locations
+## Office locations
 
 ### Göttingen, Germany
 Weender Landstraße  


### PR DESCRIPTION
Data organization work to support further automated validation, and eventually generating a website from the company profiles (see #44).

Next steps (short-term):

- [x] Automatically validate headings in company profiles
- [ ] Generate minimal company profiles for all companies in the readme
- [ ] Automatically validate that every company in the readme has a company profile