### PR TITLE
Add missing company profiles; require all companies to have a profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Name | Website | Region
 [10up](/company-profiles/10up.md) | https://10up.com/ | Worldwide
 [17hats](/company-profiles/17hats.md) | https://www.17hats.com/ | Worldwide
 [18F](/company-profiles/18f.md) | https://18f.gsa.gov/ | USA
-45royale | http://45royale.com/ |
+[45royale](/company-profiles/45royale.md) ⚠ | http://45royale.com/ |
 [Ably](/company-profiles/ably.md) | https://www.ably.io/ | Europe
 [Acquia](/company-profiles/acquia.md) | https://www.acquia.com/ | Worldwide
 [Ad Hoc](/company-profiles/ad-hoc.md) | https://www.adhocteam.us/ | USA
-Aerolab | https://aerolab.co/ |
+[Aerolab](/company-profiles/aerolab.md) ⚠ | https://aerolab.co/ |
 [AgFlow](/company-profiles/agflow.md) | http://www.agflow.com | Europe
 [AgileBits](/company-profiles/agilebits.md) | https://www.1password.com | Worldwide
 [Aha!](/company-profiles/aha.md) | http://www.aha.io | Worldwide
@@ -26,344 +26,344 @@ Aerolab | https://aerolab.co/ |
 [allyDVM](/company-profiles/allydvm.md) | http://www.allydvm.com/ | USA
 [AlphaSights](/company-profiles/alphasights.md) | https://engineering.alphasights.com | USA, UK, (EST, GMT)
 [Anexus](/company-profiles/anexus.md) | http://www.anexusit.com/ | Latin America
-AngularClass | https://angularclass.com | PST Timezone
-Anomali | https://www.anomali.com/company/careers | United States
+[AngularClass](/company-profiles/angularclass.md) ⚠ | https://angularclass.com | PST Timezone
+[Anomali](/company-profiles/anomali.md) ⚠ | https://www.anomali.com/company/careers | United States
 [apartment therapy](/company-profiles/apartment-therapy.md) | http://www.apartmenttherapy.com/ | USA
-appendTo | http://appendto.com/ |
+[appendTo](/company-profiles/appendto.md) ⚠ | http://appendto.com/ |
 [Appstractor Corporation](/company-profiles/appstractor.md) | https://www.appstractor.com/ | USA, UK, Israel
-Arkency | http://arkency.com/ | Worldwide
+[Arkency](/company-profiles/arkency.md) ⚠ | http://arkency.com/ | Worldwide
 [Art & Logic](/company-profiles/art-and-logic.md) | https://artandlogic.com | US and Canada
 [Artefactual Systems](/company-profiles/artefactual.md) | https://www.artefactual.com | UTC-8 to UTC+2
 [Articulate](/company-profiles/articulate.md) | https://www.articulate.com | Worldwide
 [Astronomer](/company-profiles/astronomer.md) | https://www.astronomer.io/ | USA
-Audiense | http://www.audiense.com/ | Worldwide
+[Audiense](/company-profiles/audiense.md) ⚠ | http://www.audiense.com/ | Worldwide
 [Auth0](/company-profiles/auth0.md) | https://auth0.com/ | Worldwide
 [Automattic](/company-profiles/automattic.md) | https://automattic.com/ | Worldwide
 [Axelerant](/company-profiles/axelerant.md) | https://axelerant.com/ | Worldwide
-Azoolla | http://www.azoolla.com/ | Europe
+[Azoolla](/company-profiles/azoolla.md) ⚠ | http://www.azoolla.com/ | Europe
 [Balsamiq](/company-profiles/balsamiq.md) | https://balsamiq.com/ | Worldwide
 [Bandcamp](/company-profiles/bandcamp.md) | https://bandcamp.com/ | Worldwide
 [Bandzoogle](/company-profiles/bandzoogle.md) | https://bandzoogle.com/ | Worldwide
 [Baremetrics](/company-profiles/baremetrics.md) | https://baremetrics.com/ | Worldwide
 [Basecamp](/company-profiles/basecamp.md) | https://basecamp.com/ | Worldwide
-BeBanjo | http://bebanjo.com/ |
-Betable | https://corp.betable.com/ |
+[BeBanjo](/company-profiles/bebanjo.md) ⚠ | http://bebanjo.com/ |
+[Betable](/company-profiles/betable.md) ⚠ | https://corp.betable.com/ |
 [Big Cartel](/company-profiles/big-cartel.md) | http://www.bigcartel.com | USA
 [Big Wheel Brigade](/company-profiles/big-wheel-brigade.md) | http://www.bigwheelbrigade.com/ | USA
 [Bitnami](/company-profiles/bitnami.md) | http://bitnami.com/ | Worldwide
 [Bitovi](/company-profiles/bitovi.md) | http://bitovi.com/ | USA & Worldwide
-Bizink | http://bizinkonline.com |
-Black Pixel | https://blackpixel.com/ |
+[Bizink](/company-profiles/bizink.md) ⚠ | http://bizinkonline.com |
+[Black Pixel](/company-profiles/black-pixel.md) ⚠ | https://blackpixel.com/ |
 [Black Tangent](/company-profiles/black-tangent.md) | http://blacktangent.io/ | WorldWide
-Bloc | https://www.bloc.io/ |
-Bluespark | https://www.bluespark.com/ |
-Brave Investments | http://www.braveinvest.com.br | Brazil
-Bright Funds | https://www.brightfunds.org |
+[Bloc](/company-profiles/bloc.md) ⚠ | https://www.bloc.io/ |
+[Bluespark](/company-profiles/bluespark.md) ⚠ | https://www.bluespark.com/ |
+[Brave Investments](/company-profiles/brave-investments.md) ⚠ | http://www.braveinvest.com.br | Brazil
+[Bright Funds](/company-profiles/bright-funds.md) ⚠ | https://www.brightfunds.org |
 [BriteCore](/company-profiles/britecore.md) | https://britecore.com/ | USA, Worldwide
 [Buffer](/company-profiles/buffer.md) | https://buffer.com/ | Worldwide
-Bulut Yazilim | https://bulutyazilim.com/ | Worldwide
-BuySellAds | https://www.buysellads.com/ |
+[Bulut Yazilim](/company-profiles/bulut-yazilim.md) ⚠ | https://bulutyazilim.com/ | Worldwide
+[BuySellAds](/company-profiles/buysellads.md) ⚠ | https://www.buysellads.com/ |
 [Canonical](/company-profiles/canonical.md) | http://www.canonical.com/ | Worldwide
-Carbon Black | https://www.carbonblack.com/ | USA, Offices in Boston, MA
-Cards Against Humanity | https://cardsagainsthumanity.com/ |
+[Carbon Black](/company-profiles/carbon-black.md) ⚠ | https://www.carbonblack.com/ | USA, Offices in Boston, MA
+[Cards Against Humanity](/company-profiles/cards-against-humanity.md) ⚠ | https://cardsagainsthumanity.com/ |
 [CareMessage](/company-profiles/caremessage.md) | http://caremessage.org/careers | Worldwide
 [CartoDB](/company-profiles/cartodb.md) | https://cartodb.com/ | Worldwide
-CartStack | http://www.cartstack.com/ |
+[CartStack](/company-profiles/cartstack.md) ⚠ | http://www.cartstack.com/ |
 [Casumo](/company-profiles/casumo.md) | https://www.casumo.com/ | Europe
 [Chargify](/company-profiles/chargify.md) | https://www.chargify.com/ | US
-charity: water | http://www.charitywater.org/ |
+[charity: water](/company-profiles/charity-water.md) ⚠ | http://www.charitywater.org/ |
 [Chef](/company-profiles/chef.md) | https://www.chef.io/ | US, UK
-CircleCI | https://circleci.com/ |
+[CircleCI](/company-profiles/circleci.md) ⚠ | https://circleci.com/ |
 [Circonus](/company-profiles/circonus.md) | https://circonus.com/ | US
 [Citrusbyte](/company-profiles/citrusbyte.md) | https://citrusbyte.com/ | Worldwide
 [Clevertech](/company-profiles/clevertech.md) | https://clevertech.biz/ | Worldwide
 [Close.io](/company-profiles/close-io.md) | http://close.io | Worldwide
 [Codea IT](/company-profiles/codea-it.md) | http://www.codeait.com | Worldwide
 [CodePen](/company-profiles/codepen.md) | https://codepen.io | Worldwide
-Codeship | https://codeship.com/ |
+[Codeship](/company-profiles/codeship.md) ⚠ | https://codeship.com/ |
 [Codestunts](/company-profiles/codestunts.md) | https://codestunts.com/ | Worldwide
 [Cofense](/company-profiles/cofense.md) | https://cofense.com | USA
 [Colivre](/company-profiles/colivre.md) | http://colivre.coop.br/ | Worldwide
-Collabora | https://www.collabora.com/ |
-Compose | https://www.compose.io/ |
+[Collabora](/company-profiles/collabora.md) ⚠ | https://www.collabora.com/ |
+[Compose](/company-profiles/compose.md) ⚠ | https://www.compose.io/ |
 [ConsenSys](/company-profiles/consensys.md) | https://consensys.net/ | Worldwide
-Consumer Financial Protection Bureau | http://www.consumerfinance.gov | USA
-Continu | https://www.continu.co/ |
+[Consumer Financial Protection Bureau](/company-profiles/consumer-financial-protection-bureau.md) ⚠ | http://www.consumerfinance.gov | USA
+[Continu](/company-profiles/continu.md) ⚠ | https://www.continu.co/ |
 [Conversio](/company-profiles/conversio.md) | https://conversio.com/ | Worldwide
 [Convert](/company-profiles/convert.md) | https://www.convert.com | Worldwide
-Core-Apps | http://www.core-apps.com/ | USA
-CoreOS | https://coreos.com/ |
+[Core-Apps](/company-profiles/core-apps.md) ⚠ | http://www.core-apps.com/ | USA
+[CoreOS](/company-profiles/coreos.md) ⚠ | https://coreos.com/ |
 [Corgibytes](/company-profiles/corgibytes.md) | http://corgibytes.com | US East Coast
 [Crew](/company-profiles/crew.md) | https://crew.co | Worldwide
-Crossover | https://www.crossover.com | Worldwide
+[Crossover](/company-profiles/crossover.md) ⚠ | https://www.crossover.com | Worldwide
 [CrowdTangle](/company-profiles/crowdtangle.md) | http://crowdtangle.com | USA
 [Customer.io](/company-profiles/customer-io.md) | https://customer.io | Worldwide
 [Dalenys](/company-profiles/dalenys.md) | https://dalenys.com/ | Europe
 [DashboardHub](/company-profiles/dashboardhub.md) | https://dashboardhub.io | Worldwide
 [Data Science Brigade](/company-profiles/data-science-brigade.md) | http://datasciencebr.com/ | Worldwide
 [Datadog](/company-profiles/datadog.md) | https://www.datadoghq.com/ | Worldwide
-DataStax | http://www.datastax.com/ |
-Datica | https://datica.com/ |
-DealDash | http://www.dealdash.com |
-Delighted | https://delighted.com |
+[DataStax](/company-profiles/datastax.md) ⚠ | http://www.datastax.com/ |
+[Datica](/company-profiles/datica.md) ⚠ | https://datica.com/ |
+[DealDash](/company-profiles/dealdash.md) ⚠ | http://www.dealdash.com |
+[Delighted](/company-profiles/delighted.md) ⚠ | https://delighted.com |
 [Dgraph](/company-profiles/dgraph.md) | https://dgraph.io/ | Americas
 [DigitalOcean](/company-profiles/digitalocean.md) | https://www.digitalocean.com/ | Worldwide
 [Discourse](/company-profiles/discourse.md) | http://www.discourse.org/ | Worldwide
 [DNSimple](/company-profiles/dnsimple.md) | https://dnsimple.com/ | Worldwide
-Docker | https://www.docker.com |
+[Docker](/company-profiles/docker.md) ⚠ | https://www.docker.com |
 [Doist](/company-profiles/doist.md) | https://doist.com | Worldwide
 [DramaFever](/company-profiles/dramafever.md) | https://www.dramafever.com/ | US
 [DroneDeploy](/company-profiles/dronedeploy.md) | https://www.dronedeploy.com/ | Worldwide
-DuckDuckGo | https://duckduckgo.com/ |
+[DuckDuckGo](/company-profiles/duckduckgo.md) ⚠ | https://duckduckgo.com/ |
 [Edgar](/company-profiles/edgar.md) | http://meetedgar.com/ | US & Canada
 [Edify](/company-profiles/edify.md) | http://edify.cr/ | Costa Rica & Worldwide
 [Elastic](/company-profiles/elastic.md) | https://www.elastic.co/ | Worldwide
-EngineYard (Support Team) | https://www.engineyard.com/ |
-Enjoei | https://www.enjoei.com.br/ | Brazil
+[EngineYard (Support Team)](/company-profiles/engineyard-support-team.md) ⚠ | https://www.engineyard.com/ |
+[Enjoei](/company-profiles/enjoei.md) ⚠ | https://www.enjoei.com.br/ | Brazil
 [Envato](/company-profiles/envato.md) | https://envato.com/ | Worldwide
-Estately | http://www.estately.com/ |
+[Estately](/company-profiles/estately.md) ⚠ | http://www.estately.com/ |
 [Etsy](/company-profiles/etsy.md) | https://www.etsy.com/ | Worldwide
-EVELO | https://evelo.workable.com |
+[EVELO](/company-profiles/evelo.md) ⚠ | https://evelo.workable.com |
 [Evil Martians](/company-profiles/evil-martians.md) | https://evilmartians.com/ | Worldwide
 [Eyeo (Adblock Plus)](/company-profiles/eyeo.md) | https://eyeo.com/ | Worldwide
-Fastly | https://www.fastly.com/ |
-Featurist | http://www.featurist.co.uk/ |
-Fetlife | https://fetlife.com/ | Worldwide
-Filament Group | https://www.filamentgroup.com/ |
+[Fastly](/company-profiles/fastly.md) ⚠ | https://www.fastly.com/ |
+[Featurist](/company-profiles/featurist.md) ⚠ | http://www.featurist.co.uk/ |
+[Fetlife](/company-profiles/fetlife.md) ⚠ | https://fetlife.com/ | Worldwide
+[Filament Group](/company-profiles/filament-group.md) ⚠ | https://www.filamentgroup.com/ |
 [Findify](/company-profiles/findify.md) | https://findify.io | UTC+2 +\- 2
-Fire Engine Red | http://fire-engine-red.com/ |
-Focusnetworks | http://focusnetworks.com.br | Brazil
+[Fire Engine Red](/company-profiles/fire-engine-red.md) ⚠ | http://fire-engine-red.com/ |
+[Focusnetworks](/company-profiles/focusnetworks.md) ⚠ | http://focusnetworks.com.br | Brazil
 [Fog Creek](/company-profiles/fog-creek-software.md) | https://www.fogcreek.com/ | Worldwide
 [Formstack](/company-profiles/formstack.md) | https://www.formstack.com/ | Worldwide
-Four Kitchens | https://fourkitchens.com/ |
-fournova | https://www.fournova.com/ |
+[Four Kitchens](/company-profiles/four-kitchens.md) ⚠ | https://fourkitchens.com/ |
+[fournova](/company-profiles/fournova.md) ⚠ | https://www.fournova.com/ |
 [Freeagent](/company-profiles/freeagent.md) | http://www.freeagent.com/ | Worldwide
 [Fuel Made](/company-profiles/fuel-made.md) | http://fuelmade.com/ | Western North America
 [FullFabric](/company-profiles/full-fabric.md) | http://fullfabric.com/ | Europe
 [Gaggle](/company-profiles/gaggle.md) | https://www.gaggle.net/ | US
-Geckoboard | https://www.geckoboard.com | UK
-General Assembly | https://generalassemb.ly/ |
+[Geckoboard](/company-profiles/geckoboard.md) ⚠ | https://www.geckoboard.com | UK
+[General Assembly](/company-profiles/general-assembly.md) ⚠ | https://generalassemb.ly/ |
 [Ghost Foundation](/company-profiles/the-ghost-foundation.md) | https://ghost.org/ | Worldwide
-Giant Swarm | https://giantswarm.io | Worldwide
+[Giant Swarm](/company-profiles/giant-swarm.md) ⚠ | https://giantswarm.io | Worldwide
 [GigSalad](/company-profiles/gigsalad.md) | https://www.gigsalad.com/ | US
-Gitbook | https://www.gitbook.com/ |
+[Gitbook](/company-profiles/gitbook.md) ⚠ | https://www.gitbook.com/ |
 [GitHub](/company-profiles/github.md) | https://github.com/ | Worldwide
-GitLab | https://about.gitlab.com/ | Worldwide
+[GitLab](/company-profiles/gitlab.md) ⚠ | https://about.gitlab.com/ | Worldwide
 [GitPrime](/company-profiles/gitprime.md) | https://gitprime.com/ | Worldwide
-Glue Networks | http://gluenetworks.com/ |
-GoHiring | http://www.gohiring.com/ | Worldwide
+[Glue Networks](/company-profiles/glue-networks.md) ⚠ | http://gluenetworks.com/ |
+[GoHiring](/company-profiles/gohiring.md) ⚠ | http://www.gohiring.com/ | Worldwide
 [Gorman Health Group](/company-profiles/gorman-health-group.md) | https://www.gormanhealthgroup.com/ | US
-GotSoccer, LLC | http://www.gotsoccerpro.com |
-Graylog | https://www.graylog.org/ |
+[GotSoccer, LLC](/company-profiles/gotsoccer-llc.md) ⚠ | http://www.gotsoccerpro.com |
+[Graylog](/company-profiles/graylog.md) ⚠ | https://www.graylog.org/ |
 [Gridium](/company-profiles/gridium.md) | http://gridium.com | US
 [Grubhub](/company-profiles/grubhub.md) | http://www.grubhub.com/ | US / Worldwide
 [Gruntwork](/company-profiles/gruntwork.md) | http://www.gruntwork.io/ | Worldwide
 [Hack Reactor Remote](/company-profiles/hack-reactor-remote.md) | http://www.hackreactor.com/remote/ | Pacific Time Zone (PT)
-Haiku Learning | http://www.haikulearning.com/ |
-Hanno | https://hanno.co/ | Worldwide
+[Haiku Learning](/company-profiles/haiku-learning.md) ⚠ | http://www.haikulearning.com/ |
+[Hanno](/company-profiles/hanno.md) ⚠ | https://hanno.co/ | Worldwide
 [Hanzo](/company-profiles/hanzo.md) | https://hanzo.co | US, UK, Europe
 [Happy Bear Software](/company-profiles/happy-bear-software.md) | https://www.happybearsoftware.com/ | Worldwide
-Happy Cog | http://happycog.com/ | USA
+[Happy Cog](/company-profiles/happy-cog.md) ⚠ | http://happycog.com/ | USA
 [Harvest](/company-profiles/harvest.md) | https://www.getharvest.com/ | Worldwide
-HashiCorp | https://www.hashicorp.com/ |
+[HashiCorp](/company-profiles/hashicorp.md) ⚠ | https://www.hashicorp.com/ |
 [HE:labs](/company-profiles/he-labs.md) | https://www.helabs.com | Worldwide
-Healthfinch | http://www.healthfinch.com/ |
+[Healthfinch](/company-profiles/healthfinch.md) ⚠ | http://www.healthfinch.com/ |
 [Heap](/company-profiles/heap.md) | https://heapanalytics.com/ | Worldwide
-Help Scout | https://www.helpscout.net/ |
-Heroku | https://www.heroku.com/ |
+[Help Scout](/company-profiles/help-scout.md) ⚠ | https://www.helpscout.net/ |
+[Heroku](/company-profiles/heroku.md) ⚠ | https://www.heroku.com/ |
 [Hireology](/company-profiles/hireology.md) | https://www.hireology.com | United States
-Honeybadger | https://www.honeybadger.io/ |
+[Honeybadger](/company-profiles/honeybadger.md) ⚠ | https://www.honeybadger.io/ |
 [Honeycomb](/company-profiles/honeycomb.md) | https://honeycomb.tv/ | Worldwide
-Hotjar | http://careers.hotjar.com/ | Worldwide
+[Hotjar](/company-profiles/hotjar.md) ⚠ | http://careers.hotjar.com/ | Worldwide
 [Hudl](/company-profiles/hudl.md) | http://www.hudl.com/ | US & UK
 [Hugo](/company-profiles/hugo.md) | https://hugo.events | Worldwide
 [Human Made](/company-profiles/human-made.md) | https://hmn.md | Worldwide
 [Hyperion](/company-profiles/hyperion.md) | https://hyperiondev.com/jobs | South Africa
 [Hypothesis](/company-profiles/hypothesis.md) | https://hypothes.is | Worldwide
-IDoneThis | https://idonethis.com/ |
-Igalia | http://www.igalia.com/ |
+[IDoneThis](/company-profiles/idonethis.md) ⚠ | https://idonethis.com/ |
+[Igalia](/company-profiles/igalia.md) ⚠ | http://www.igalia.com/ |
 [Incsub](/company-profiles/incsub.md) | https://incsub.com/ | Worldwide
-InfluxData | https://influxdata.com |
-Inpsyde | http://inpsyde.com/en/ |
+[InfluxData](/company-profiles/influxdata.md) ⚠ | https://influxdata.com |
+[Inpsyde](/company-profiles/inpsyde.md) ⚠ | http://inpsyde.com/en/ |
 [InQuicker](/company-profiles/inquicker.md) | https://inquicker.com | US & CA
-Intellum | http://www.intellum.com |
+[Intellum](/company-profiles/intellum.md) ⚠ | http://www.intellum.com |
 [Interactive Intelligence](/company-profiles/interactive-intelligence.md) | https://www.inin.com/ | Worldwide
 [Intercom](/company-profiles/intercom.md) | https://www.intercom.io/ | Worldwide
-Interpersonal Frequency (I.F.) | https://ifsight.com/ |
-InVision | http://www.invisionapp.com/ |
+[Interpersonal Frequency (I.F.)](/company-profiles/interpersonal-frequency-i-f.md) ⚠ | https://ifsight.com/ |
+[InVision](/company-profiles/invision.md) ⚠ | http://www.invisionapp.com/ |
 [IOpipe](/company-profiles/iopipe.md) | https://www.iopipe.com | USA
-IPS Group, Inc. | http://www.ipsgroupinc.com/ |
+[IPS Group, Inc.](/company-profiles/ips-group-inc.md) ⚠ | http://www.ipsgroupinc.com/ |
 [iwantmyname](/company-profiles/iwantmyname.md) | https://iwantmyname.com/ | Worldwide
 [Jackson River](/company-profiles/jackson-river.md) | http://jacksonriver.com/ | US
 [Jitbit](/company-profiles/jitbit.md) | https://www.jitbit.com/ | Worldwide
-Jolly Good Code | http://www.jollygoodcode.com |
-Keen IO | https://keen.io/ |
-Khan Academy | https://www.khanacademy.org/ |
-KickBack Rewards Systems | http://careers.kickbacksystems.com |
+[Jolly Good Code](/company-profiles/jolly-good-code.md) ⚠ | http://www.jollygoodcode.com |
+[Keen IO](/company-profiles/keen-io.md) ⚠ | https://keen.io/ |
+[Khan Academy](/company-profiles/khan-academy.md) ⚠ | https://www.khanacademy.org/ |
+[KickBack Rewards Systems](/company-profiles/kickback-rewards-systems.md) ⚠ | http://careers.kickbacksystems.com |
 [Kiprosh](/company-profiles/kiprosh.md) | http://kiprosh.com | USA & India
 [Kissmetrics](/company-profiles/kissmetrics.md) | https://www.kissmetrics.com/ | USA & Worldwide
 [Knack](/company-profiles/knack.md) | https://www.knackhq.com | US
 [Kodify](/company-profiles/kodify.md) | https://kodify.io | EU & Worldwide
-Koding | https://koding.com | Worldwide
+[Koding](/company-profiles/koding.md) ⚠ | https://koding.com | Worldwide
 [LaterPay](/company-profiles/laterpay.md) | https://www.laterpay.net/ |
 [Let's Encrypt](/company-profiles/let-s-encrypt.md) | https://letsencrypt.org | US and Canada
-Librato | https://www.librato.com/ |
-Lightbend | http://www.lightbend.com/ | Worldwide
-Linaro | https://www.linaro.org/ |
-Lincoln Loop | https://lincolnloop.com/ |
-Linux Foundation | http://www.linuxfoundation.org/ |
+[Librato](/company-profiles/librato.md) ⚠ | https://www.librato.com/ |
+[Lightbend](/company-profiles/lightbend.md) ⚠ | http://www.lightbend.com/ | Worldwide
+[Linaro](/company-profiles/linaro.md) ⚠ | https://www.linaro.org/ |
+[Lincoln Loop](/company-profiles/lincoln-loop.md) ⚠ | https://lincolnloop.com/ |
+[Linux Foundation](/company-profiles/linux-foundation.md) ⚠ | http://www.linuxfoundation.org/ |
 [Litmus](/company-profiles/litmus.md) | https://litmus.com/ | Worldwide
-LivingSocial | https://www.livingsocial.com/ |
+[LivingSocial](/company-profiles/livingsocial.md) ⚠ | https://www.livingsocial.com/ |
 [Loadsys Web Strategies](/company-profiles/loadsys.md) | https://www.loadsys.com | US Only
 [Localistico](/company-profiles/localistico.md) | [https://localistico.com](http://localistico.com/team/#hiring) | Worldwide
 [Lullabot](/company-profiles/lullabot.md) | https://www.lullabot.com/ | Worldwide
 [Manifold](/company-profiles/manifold.md) | https://manifold.co | UTC-9 to UTC+1
 [Mapbox](/company-profiles/mapbox.md) | https://www.mapbox.com/ | Worldwide
-Marketade | http://www.marketade.com |
+[Marketade](/company-profiles/marketade.md) ⚠ | http://www.marketade.com |
 [MarsBased](/company-profiles/marsbased.md) | https://marsbased.com/ | Worldwide
 [Mediacurrent](/company-profiles/mediacurrent.md) | https://www.mediacurrent.com/ | US Only
-Memberful | https://memberful.com |
-MetaLab | http://metalab.co |
-Mixcloud | https://www.mixcloud.com/ |
+[Memberful](/company-profiles/memberful.md) ⚠ | https://memberful.com |
+[MetaLab](/company-profiles/metalab.md) ⚠ | http://metalab.co |
+[Mixcloud](/company-profiles/mixcloud.md) ⚠ | https://www.mixcloud.com/ |
 [Mixmax](/company-profiles/mixmax.md) | https://mixmax.com | Worldwide
-Mokriya | http://mokriya.com |
-Mozilla | https://www.mozilla.org/ |
+[Mokriya](/company-profiles/mokriya.md) ⚠ | http://mokriya.com |
+[Mozilla](/company-profiles/mozilla.md) ⚠ | https://www.mozilla.org/ |
 [mtc.](/company-profiles/mtc.md) | http://www.mtcmedia.co.uk | UK & Europe
 [Muck Rack](/company-profiles/muck-rack.md) | https://muckrack.com | Worldwide
-Mycelium | https://mycelium.com |
-MySQL | https://www.mysql.com/ |
-Netguru | https://www.netguru.co |
+[Mycelium](/company-profiles/mycelium.md) ⚠ | https://mycelium.com |
+[MySQL](/company-profiles/mysql.md) ⚠ | https://www.mysql.com/ |
+[Netguru](/company-profiles/netguru.md) ⚠ | https://www.netguru.co |
 [Netsparker](/company-profiles/netsparker.md) | https://www.netsparker.com/ | Worldwide
 [Nettl Edinburgh](/company-profiles/nettl-edinburgh.md) | http://www.webdesignedinburgh.com | UK & Europe
 [New Context](/company-profiles/new-context.md) | https://www.newcontext.com/ | US
-Next Big Sound | https://www.nextbigsound.com/ |
+[Next Big Sound](/company-profiles/next-big-sound.md) ⚠ | https://www.nextbigsound.com/ |
 [NodeSource](/company-profiles/nodesource.md) | https://nodesource.com/ | Worldwide
 [NoRedInk](/company-profiles/noredink.md) | https://noredink.com | UTC-8 to UTC+1
 [Novoda](/company-profiles/novoda.md) | https://www.novoda.com/ | UK & Europe
-npm | https://www.npmjs.com/ |
-O'Reilly Media | http://www.oreilly.com/ |
+[npm](/company-profiles/npm.md) ⚠ | https://www.npmjs.com/ |
+[O'Reilly Media](/company-profiles/o-reilly-media.md) ⚠ | http://www.oreilly.com/ |
 [Oddball](/company-profiles/oddball.md) | https://oddball.io/ | US
 [Olark](/company-profiles/olark.md) | https://www.olark.com/ | UTC-8 to UTC+1
 [Olo](/company-profiles/olo.md) | https://www.olo.com/ | US
 [OmniTI](/company-profiles/omniti.md) | https://omniti.com/ | US
-OpenCraft | http://opencraft.com/ |
-Oracle | http://www.oracle.com/ | Worldwide
-Our-Hometown Inc. | http://our-hometown.com/ | US
+[OpenCraft](/company-profiles/opencraft.md) ⚠ | http://opencraft.com/ |
+[Oracle](/company-profiles/oracle.md) ⚠ | http://www.oracle.com/ | Worldwide
+[Our-Hometown Inc.](/company-profiles/our-hometown-inc.md) ⚠ | http://our-hometown.com/ | US
 [PagerDuty](/company-profiles/pagerduty.md) | https://pagerduty.com | US
 [Paktor](/company-profiles/paktor.md) | https://www.gopaktor.com/ | Worldwide
 [Palantir.net](/company-profiles/palantir-net.md) | https://www.palantir.net/ | US
 [Park Assist](/company-profiles/park-assist.md) | http://tech.parkassist.com | UTC-8 to UTC+2
-Parker Wallace | http://www.parkerwallace.com/ |
-Parsely | http://www.parsely.com/ |
-Particular Software | http://particular.net |
-Pathable | https://pathable.com/ |
+[Parker Wallace](/company-profiles/parker-wallace.md) ⚠ | http://www.parkerwallace.com/ |
+[Parsely](/company-profiles/parsely.md) ⚠ | http://www.parsely.com/ |
+[Particular Software](/company-profiles/particular-software.md) ⚠ | http://particular.net |
+[Pathable](/company-profiles/pathable.md) ⚠ | https://pathable.com/ |
 [Payfully](/company-profiles/payfully.md) | https://www.payfully.co | Worldwide
-Paylocity | http://www.paylocity.com/ |
-PeachWorks | https://peachworks.com/ |
-Pelagicore | http://www.pelagicore.com |
-PeopleDoc | http://www.people-doc.com |
+[Paylocity](/company-profiles/paylocity.md) ⚠ | http://www.paylocity.com/ |
+[PeachWorks](/company-profiles/peachworks.md) ⚠ | https://peachworks.com/ |
+[Pelagicore](/company-profiles/pelagicore.md) ⚠ | http://www.pelagicore.com |
+[PeopleDoc](/company-profiles/peopledoc.md) ⚠ | http://www.people-doc.com |
 [Percona](/company-profiles/percona.md) | https://www.percona.com | Worldwide
 [Platform.sh](/company-profiles/platform-sh.md) | https://platform.sh/ | Worldwide
-Precision Nutrition | http://www.precisionnutrition.com/ |
-PreviousNext | https://www.previousnext.com.au/ |
+[Precision Nutrition](/company-profiles/precision-nutrition.md) ⚠ | http://www.precisionnutrition.com/ |
+[PreviousNext](/company-profiles/previousnext.md) ⚠ | https://www.previousnext.com.au/ |
 [Prezly](/company-profiles/prezly.md) | https://www.prezly.com/ | Worldwide
 [Puppet](/company-profiles/puppet.md) | https://puppet.com/ | Worldwide
 [Rackspace](/company-profiles/rackspace.md) | https://rackspace.com/ | Worldwide
-Rainforest QA | https://www.rainforestqa.com/jobs/ |
+[Rainforest QA](/company-profiles/rainforest-qa.md) ⚠ | https://www.rainforestqa.com/jobs/ |
 [ReactiveOps, Inc.](/company-profiles/reactiveops.md) | https://www.reactiveops.com | USA
-RealHQ | https://realhq.com/ |
-RebelMouse | https://www.rebelmouse.com/ |
-Receiptful | https://receiptful.com |
+[RealHQ](/company-profiles/realhq.md) ⚠ | https://realhq.com/ |
+[RebelMouse](/company-profiles/rebelmouse.md) ⚠ | https://www.rebelmouse.com/ |
+[Receiptful](/company-profiles/receiptful.md) ⚠ | https://receiptful.com |
 [ReCharge](/company-profiles/recharge.md) | http://rechargepayments.com/ | Worldwide
-Recurly | https://recurly.com/ |
+[Recurly](/company-profiles/recurly.md) ⚠ | https://recurly.com/ |
 [Red Hat](/company-profiles/red-hat.md) | https://www.redhat.com | Worldwide
-RedMonk | http://redmonk.com/ |
-reinteractive | https://reinteractive.net/ |
-Research Square | https://www.researchsquare.com/ |
-RightScale | http://www.rightscale.com/ |
+[RedMonk](/company-profiles/redmonk.md) ⚠ | http://redmonk.com/ |
+[reinteractive](/company-profiles/reinteractive.md) ⚠ | https://reinteractive.net/ |
+[Research Square](/company-profiles/research-square.md) ⚠ | https://www.researchsquare.com/ |
+[RightScale](/company-profiles/rightscale.md) ⚠ | http://www.rightscale.com/ |
 [rtCamp](/company-profiles/rtcamp-solutions.md) | https://rtcamp.com | India
-Safari Books Online | https://www.safaribooksonline.com |
-Salesforce | https://www.salesforce.com/ |
+[Safari Books Online](/company-profiles/safari-books-online.md) ⚠ | https://www.safaribooksonline.com |
+[Salesforce](/company-profiles/salesforce.md) ⚠ | https://www.salesforce.com/ |
 [Sandhills Development](/company-profiles/sandhills-development.md) | http://sandhillsdev.com | Worldwide
-Sawhorse Media | http://sawhorsemedia.com |
-Scrapinghub | http://scrapinghub.com/ |
-SecurityScorecard | https://securityscorecard.com/ |
-SEED | https://seed.co/ |
+[Sawhorse Media](/company-profiles/sawhorse-media.md) ⚠ | http://sawhorsemedia.com |
+[Scrapinghub](/company-profiles/scrapinghub.md) ⚠ | http://scrapinghub.com/ |
+[SecurityScorecard](/company-profiles/securityscorecard.md) ⚠ | https://securityscorecard.com/ |
+[SEED](/company-profiles/seed.md) ⚠ | https://seed.co/ |
 [Sensu](/company-profiles/sensu.md) | https://sensuapp.org | United States and Canada
 [Server Density](/company-profiles/server-density.md) | https://www.serverdensity.com | Europe
-SignEasy | http://getsigneasy.com |
+[SignEasy](/company-profiles/signeasy.md) ⚠ | http://getsigneasy.com |
 [simplabs](/company-profiles/simplabs.md) | http://simplabs.com/ | Europe and Americas
 [Simple](/company-profiles/simple.md) | https://www.simple.com/ | United States
 [SimpleTexting](/company-profiles/simpletexting.md) | https://simpletexting.com/ | Worldwide
 [Six to Start](/company-profiles/six-to-start.md) | http://sixtostart.com | Worldwide
 [Skillcrush](/company-profiles/skillcrush.md) | http://skillcrush.com | Worldwide
-Skillshare | https://www.skillshare.com/teach |
-SmugMug | https://www.smugmug.com/ |
-SoftwareMill | https://softwaremill.com/ |
-Soostone | http://www.soostone.com/ |
+[Skillshare](/company-profiles/skillshare.md) ⚠ | https://www.skillshare.com/teach |
+[SmugMug](/company-profiles/smugmug.md) ⚠ | https://www.smugmug.com/ |
+[SoftwareMill](/company-profiles/softwaremill.md) ⚠ | https://softwaremill.com/ |
+[Soostone](/company-profiles/soostone.md) ⚠ | http://www.soostone.com/ |
 [Spoqa](/company-profiles/spoqa.md) | http://www.spoqa.com/ | South Korea and Japan
 [Spreedly](/company-profiles/spreedly.md) | https://spreedly.com/ | United States
 [Stack Exchange](/company-profiles/stack-exchange.md) | http://stackexchange.com/ | Worldwide
 [Stairlin](/company-profiles/stairlin.md) | https://www.stairlin.com/ | Worldwide
 [Status](/company-profiles/status.md) | https://www.status.im/ | Worldwide
 [Stencil](/company-profiles/stencil.md) | https://getstencil.com/ | United States and Canada
-Stitch Fix | https://www.stitchfix.com |
+[Stitch Fix](/company-profiles/stitch-fix.md) ⚠ | https://www.stitchfix.com |
 [Stripe](/company-profiles/stripe.md) | https://stripe.com/ | Worldwide
-Strongloop | https://strongloop.com/ |
+[Strongloop](/company-profiles/strongloop.md) ⚠ | https://strongloop.com/ |
 [StudySoup](/company-profiles/studysoup.md) | https://studysoup.com/ | Worldwide
-Surevine | https://www.surevine.com/ |
-SUSE | https://www.suse.com/ | Worldwide
-Sutherland CloudSource | https://www.sutherlandcloudsource.com |
-SweetRush | http://www.sweetrush.com |
-Sysdig | http://www.sysdig.org/ |
-Tag1 Consulting | https://tag1consulting.com/ | Worldwide
-Taplytics | https://taplytics.com/ |
+[Surevine](/company-profiles/surevine.md) ⚠ | https://www.surevine.com/ |
+[SUSE](/company-profiles/suse.md) ⚠ | https://www.suse.com/ | Worldwide
+[Sutherland CloudSource](/company-profiles/sutherland-cloudsource.md) ⚠ | https://www.sutherlandcloudsource.com |
+[SweetRush](/company-profiles/sweetrush.md) ⚠ | http://www.sweetrush.com |
+[Sysdig](/company-profiles/sysdig.md) ⚠ | http://www.sysdig.org/ |
+[Tag1 Consulting](/company-profiles/tag1-consulting.md) ⚠ | https://tag1consulting.com/ | Worldwide
+[Taplytics](/company-profiles/taplytics.md) ⚠ | https://taplytics.com/ |
 [Taskade](/company-profiles/taskade.md) | https://taskade.com/ | Worldwide
 [TaxJar](/company-profiles/taxjar.md) | https://www.taxjar.com | United States
-teamed. | http://www.teamed.io/ |
-TeamSnap | https://www.teamsnap.com |
-TED | https://www.ted.com/ |
-Teleport | http://teleport.org/ |
-Telerik | http://www.telerik.com/ |
-Tenable | http://www.tenable.com/ |
-Test Double | http://testdouble.com/ |
+[teamed.](/company-profiles/teamed.md) ⚠ | http://www.teamed.io/ |
+[TeamSnap](/company-profiles/teamsnap.md) ⚠ | https://www.teamsnap.com |
+[TED](/company-profiles/ted.md) ⚠ | https://www.ted.com/ |
+[Teleport](/company-profiles/teleport.md) ⚠ | http://teleport.org/ |
+[Telerik](/company-profiles/telerik.md) ⚠ | http://www.telerik.com/ |
+[Tenable](/company-profiles/tenable.md) ⚠ | http://www.tenable.com/ |
+[Test Double](/company-profiles/test-double.md) ⚠ | http://testdouble.com/ |
 [The Grid](/company-profiles/the-grid.md) | https://thegrid.io/ | Worldwide
-The Publisher Desk | http://www.publisherdesk.com |
-The Remote Lab | http://theremotelab.io |
+[The Publisher Desk](/company-profiles/the-publisher-desk.md) ⚠ | http://www.publisherdesk.com |
+[The Remote Lab](/company-profiles/the-remote-lab.md) ⚠ | http://theremotelab.io |
 [The Scale Factory](/company-profiles/the-scale-factory.md) | http://www.scalefactory.com/ | UK
 [The Wirecutter](/company-profiles/the-wirecutter.md) | http://thewirecutter.com/ | Worldwide
 [Thinkful](/company-profiles/thinkful.md) | https://www.thinkful.com/ | WorldWide
-TIDY Homekeeping | http://tidy.com/ | United States
+[TIDY Homekeeping](/company-profiles/tidy-homekeeping.md) ⚠ | http://tidy.com/ | United States
 [TimeSpot](/company-profiles/timespot.md) | https://timespothq.com/ | Worldwide
 [toggl](/company-profiles/toggl.md) | https://toggl.com/ | Worldwide
 [Toptal](/company-profiles/toptal.md) | https://www.toptal.com/ | Worldwide
-Tractionboard | https://tractionboard.com/ |
+[Tractionboard](/company-profiles/tractionboard.md) ⚠ | https://tractionboard.com/ |
 [Transloadit](/company-profiles/transloadit.md) | https://transloadit.com/ | Worldwide
-Travis CI | https://travis-ci.org/ |
+[Travis CI](/company-profiles/travis-ci.md) ⚠ | https://travis-ci.org/ |
 [Treehouse](/company-profiles/treehouse.md) | https://teamtreehouse.com/ | United States
-Trello | https://trello.com/ |
-Twin Technologies | https://www.twintechs.com/ |
+[Trello](/company-profiles/trello.md) ⚠ | https://trello.com/ |
+[Twin Technologies](/company-profiles/twin-technologies.md) ⚠ | https://www.twintechs.com/ |
 [Udacity](/company-profiles/udacity.md) | https://www.udacity.com/ | Worldwide
-UpTrending | http://uptrending.com |
-Upwork Pro | https://www.upwork.com |
-Upworthy | https://www.upworthy.com/ | Worldwide (U.S. Timezone)
+[UpTrending](/company-profiles/uptrending.md) ⚠ | http://uptrending.com |
+[Upwork Pro](/company-profiles/upwork-pro.md) ⚠ | https://www.upwork.com |
+[Upworthy](/company-profiles/upworthy.md) ⚠ | https://www.upworthy.com/ | Worldwide (U.S. Timezone)
 [Ushahidi](/company-profiles/ushahidi.md) | https://www.ushahidi.com | Worldwide
-Varnish Software | https://www.varnish-software.com/about-us | Worldwide
-Vox Media (Product Team) | http://www.voxmedia.com/ |
-WebDevStudios | https://webdevstudios.com/ |
+[Varnish Software](/company-profiles/varnish-software.md) ⚠ | https://www.varnish-software.com/about-us | Worldwide
+[Vox Media (Product Team)](/company-profiles/vox-media-product-team.md) ⚠ | http://www.voxmedia.com/ |
+[WebDevStudios](/company-profiles/webdevstudios.md) ⚠ | https://webdevstudios.com/ |
 [Webikon](/company-profiles/webikon.md) | http://www.webikon.sk/en/ | Worldwide
-WellMatch | https://www.wellmatchhealth.com/ |
+[WellMatch](/company-profiles/wellmatch.md) ⚠ | https://www.wellmatchhealth.com/ |
 [wemake.services](/company-profiles/wemake-services.md) | https://wemake.services/ | Worldwide
-Whitecap SEO | http://www.whitecapseo.com/ |
-Whitespectre | http://whitespectre.com |
-WikiHow | http://www.wikihow.com/wikiHow:About-wikiHow | PST Timezone
+[Whitecap SEO](/company-profiles/whitecap-seo.md) ⚠ | http://www.whitecapseo.com/ |
+[Whitespectre](/company-profiles/whitespectre.md) ⚠ | http://whitespectre.com |
+[WikiHow](/company-profiles/wikihow.md) ⚠ | http://www.wikihow.com/wikiHow:About-wikiHow | PST Timezone
 [Wikimedia Foundation](/company-profiles/wikimedia-foundation.md) | https://wikimediafoundation.org | Worldwide
 [Wildbit](/company-profiles/wildbit.md) | http://wildbit.com/ | USA & Worldwide
 [Wolfram](/company-profiles/wolfram.md) | https://www.wolfram.com | Worldwide
-Wombat Security Technologies | https://www.wombatsecurity.com/ | USA
-Word to the Wise | https://wordtothewise.com |
-X-Team | http://x-team.com/ |
-Yonder | https://www.yonder.io | Worldwide
-YouCanBook.me Ltd | https://youcanbook.me |
+[Wombat Security Technologies](/company-profiles/wombat-security-technologies.md) ⚠ | https://www.wombatsecurity.com/ | USA
+[Word to the Wise](/company-profiles/word-to-the-wise.md) ⚠ | https://wordtothewise.com |
+[X-Team](/company-profiles/x-team.md) ⚠ | http://x-team.com/ |
+[Yonder](/company-profiles/yonder.md) ⚠ | https://www.yonder.io | Worldwide
+[YouCanBook.me Ltd](/company-profiles/youcanbook-me-ltd.md) ⚠ | https://youcanbook.me |
 [Zapier](/company-profiles/zapier.md) | https://zapier.com/ | Worldwide
 [Zeit.io](/company-profiles/zeit-io.md) | http://zeit.io/ | Germany, The Netherlands, Spain, Chile

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Name | Website | Region
 [Edgar](/company-profiles/edgar.md) | http://meetedgar.com/ | US & Canada
 [Edify](/company-profiles/edify.md) | http://edify.cr/ | Costa Rica & Worldwide
 [Elastic](/company-profiles/elastic.md) | https://www.elastic.co/ | Worldwide
-[EngineYard (Support Team)](/company-profiles/engineyard-support-team.md) ⚠ | https://www.engineyard.com/ |
+[EngineYard (Support Team)](/company-profiles/engineyard.md) ⚠ | https://www.engineyard.com/ |
 [Enjoei](/company-profiles/enjoei.md) ⚠ | https://www.enjoei.com.br/ | Brazil
 [Envato](/company-profiles/envato.md) | https://envato.com/ | Worldwide
 [Estately](/company-profiles/estately.md) ⚠ | http://www.estately.com/ |
@@ -349,7 +349,7 @@ Name | Website | Region
 [Upworthy](/company-profiles/upworthy.md) ⚠ | https://www.upworthy.com/ | Worldwide (U.S. Timezone)
 [Ushahidi](/company-profiles/ushahidi.md) | https://www.ushahidi.com | Worldwide
 [Varnish Software](/company-profiles/varnish-software.md) ⚠ | https://www.varnish-software.com/about-us | Worldwide
-[Vox Media (Product Team)](/company-profiles/vox-media-product-team.md) ⚠ | http://www.voxmedia.com/ |
+[Vox Media (Product Team)](/company-profiles/vox-media.md) ⚠ | http://www.voxmedia.com/ |
 [WebDevStudios](/company-profiles/webdevstudios.md) ⚠ | https://webdevstudios.com/ |
 [Webikon](/company-profiles/webikon.md) | http://www.webikon.sk/en/ | Worldwide
 [WellMatch](/company-profiles/wellmatch.md) ⚠ | https://www.wellmatchhealth.com/ |
@@ -360,10 +360,10 @@ Name | Website | Region
 [Wikimedia Foundation](/company-profiles/wikimedia-foundation.md) | https://wikimediafoundation.org | Worldwide
 [Wildbit](/company-profiles/wildbit.md) | http://wildbit.com/ | USA & Worldwide
 [Wolfram](/company-profiles/wolfram.md) | https://www.wolfram.com | Worldwide
-[Wombat Security Technologies](/company-profiles/wombat-security-technologies.md) ⚠ | https://www.wombatsecurity.com/ | USA
+[Wombat Security Technologies](/company-profiles/wombat-security.md) ⚠ | https://www.wombatsecurity.com/ | USA
 [Word to the Wise](/company-profiles/word-to-the-wise.md) ⚠ | https://wordtothewise.com |
 [X-Team](/company-profiles/x-team.md) ⚠ | http://x-team.com/ |
 [Yonder](/company-profiles/yonder.md) ⚠ | https://www.yonder.io | Worldwide
-[YouCanBook.me Ltd](/company-profiles/youcanbook-me-ltd.md) ⚠ | https://youcanbook.me |
+[YouCanBook.me Ltd](/company-profiles/youcanbook-me.md) ⚠ | https://youcanbook.me |
 [Zapier](/company-profiles/zapier.md) | https://zapier.com/ | Worldwide
 [Zeit.io](/company-profiles/zeit-io.md) | http://zeit.io/ | Germany, The Netherlands, Spain, Chile

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Focusnetworks | http://focusnetworks.com.br | Brazil
 [Fog Creek](/company-profiles/fog-creek-software.md) | https://www.fogcreek.com/ | Worldwide
 [Formstack](/company-profiles/formstack.md) | https://www.formstack.com/ | Worldwide
 Four Kitchens | https://fourkitchens.com/ |
+fournova | https://www.fournova.com/ |
 [Freeagent](/company-profiles/freeagent.md) | http://www.freeagent.com/ | Worldwide
 [Fuel Made](/company-profiles/fuel-made.md) | http://fuelmade.com/ | Western North America
 [FullFabric](/company-profiles/full-fabric.md) | http://fullfabric.com/ | Europe
@@ -336,7 +337,6 @@ TIDY Homekeeping | http://tidy.com/ | United States
 [TimeSpot](/company-profiles/timespot.md) | https://timespothq.com/ | Worldwide
 [toggl](/company-profiles/toggl.md) | https://toggl.com/ | Worldwide
 [Toptal](/company-profiles/toptal.md) | https://www.toptal.com/ | Worldwide
-Tower / fournova | https://www.fournova.com/ |
 Tractionboard | https://tractionboard.com/ |
 [Transloadit](/company-profiles/transloadit.md) | https://transloadit.com/ | Worldwide
 Travis CI | https://travis-ci.org/ |

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ Delighted | https://delighted.com |
 [DNSimple](/company-profiles/dnsimple.md) | https://dnsimple.com/ | Worldwide
 Docker | https://www.docker.com |
 [Doist](/company-profiles/doist.md) | https://doist.com | Worldwide
-[DramaFever](/company-profiles/dramafever.md)  | https://www.dramafever.com/ | US
-[DroneDeploy](/company-profiles/dronedeploy.md)  | https://www.dronedeploy.com/ | Worldwide
+[DramaFever](/company-profiles/dramafever.md) | https://www.dramafever.com/ | US
+[DroneDeploy](/company-profiles/dronedeploy.md) | https://www.dronedeploy.com/ | Worldwide
 DuckDuckGo | https://duckduckgo.com/ |
 [Edgar](/company-profiles/edgar.md) | http://meetedgar.com/ | US & Canada
 [Edify](/company-profiles/edify.md) | http://edify.cr/ | Costa Rica & Worldwide
@@ -192,7 +192,7 @@ Intellum | http://www.intellum.com |
 Interpersonal Frequency (I.F.) | https://ifsight.com/ |
 InVision | http://www.invisionapp.com/ |
 [IOpipe](/company-profiles/iopipe.md) | https://www.iopipe.com | USA
-IPS Group, Inc. |  http://www.ipsgroupinc.com/ |
+IPS Group, Inc. | http://www.ipsgroupinc.com/ |
 [iwantmyname](/company-profiles/iwantmyname.md) | https://iwantmyname.com/ | Worldwide
 [Jackson River](/company-profiles/jackson-river.md) | http://jacksonriver.com/ | US
 [Jitbit](/company-profiles/jitbit.md) | https://www.jitbit.com/ | Worldwide
@@ -250,23 +250,23 @@ OpenCraft | http://opencraft.com/ |
 Oracle | http://www.oracle.com/ | Worldwide
 Our-Hometown Inc. | http://our-hometown.com/ | US
 [PagerDuty](/company-profiles/pagerduty.md) | https://pagerduty.com | US
-[Paktor](/company-profiles/paktor.md)  | https://www.gopaktor.com/ | Worldwide
+[Paktor](/company-profiles/paktor.md) | https://www.gopaktor.com/ | Worldwide
 [Palantir.net](/company-profiles/palantir-net.md) | https://www.palantir.net/ | US
 [Park Assist](/company-profiles/park-assist.md) | http://tech.parkassist.com | UTC-8 to UTC+2
 Parker Wallace | http://www.parkerwallace.com/ |
 Parsely | http://www.parsely.com/ |
 Particular Software | http://particular.net |
-Pathable, Inc.  | https://www.jobscore.com/ |
+Pathable | https://pathable.com/ |
 [Payfully](/company-profiles/payfully.md) | https://www.payfully.co | Worldwide
 Paylocity | http://www.paylocity.com/ |
 PeachWorks | https://peachworks.com/ |
 Pelagicore | http://www.pelagicore.com |
 PeopleDoc | http://www.people-doc.com |
-[Percona](/company-profiles/percona.md) | https://www.percona.com  | Worldwide
-[Platform.sh](/company-profiles/platform-sh.md)  | https://platform.sh/ | Worldwide
+[Percona](/company-profiles/percona.md) | https://www.percona.com | Worldwide
+[Platform.sh](/company-profiles/platform-sh.md) | https://platform.sh/ | Worldwide
 Precision Nutrition | http://www.precisionnutrition.com/ |
 PreviousNext | https://www.previousnext.com.au/ |
-[Prezly](/company-profiles/prezly.md)  | https://www.prezly.com/ | Worldwide
+[Prezly](/company-profiles/prezly.md) | https://www.prezly.com/ | Worldwide
 [Puppet](/company-profiles/puppet.md) | https://puppet.com/ | Worldwide
 [Rackspace](/company-profiles/rackspace.md) | https://rackspace.com/ | Worldwide
 Rainforest QA | https://www.rainforestqa.com/jobs/ |
@@ -287,7 +287,7 @@ Salesforce | https://www.salesforce.com/ |
 [Sandhills Development](/company-profiles/sandhills-development.md) | http://sandhillsdev.com | Worldwide
 Sawhorse Media | http://sawhorsemedia.com |
 Scrapinghub | http://scrapinghub.com/ |
-SecurityScorecard Inc.  | https://securityscorecard.com/ |
+SecurityScorecard | https://securityscorecard.com/ |
 SEED | https://seed.co/ |
 [Sensu](/company-profiles/sensu.md) | https://sensuapp.org | United States and Canada
 [Server Density](/company-profiles/server-density.md) | https://www.serverdensity.com | Europe
@@ -297,7 +297,7 @@ SignEasy | http://getsigneasy.com |
 [SimpleTexting](/company-profiles/simpletexting.md) | https://simpletexting.com/ | Worldwide
 [Six to Start](/company-profiles/six-to-start.md) | http://sixtostart.com | Worldwide
 [Skillcrush](/company-profiles/skillcrush.md) | http://skillcrush.com | Worldwide
-Skillshare  | https://www.skillshare.com/teach |
+Skillshare | https://www.skillshare.com/teach |
 SmugMug | https://www.smugmug.com/ |
 SoftwareMill | https://softwaremill.com/ |
 Soostone | http://www.soostone.com/ |
@@ -313,7 +313,7 @@ Strongloop | https://strongloop.com/ |
 [StudySoup](/company-profiles/studysoup.md) | https://studysoup.com/ | Worldwide
 Surevine | https://www.surevine.com/ |
 SUSE | https://www.suse.com/ | Worldwide
-Sutherland Global Services - CloudSource  | https://www.sutherlandcloudsource.com |
+Sutherland CloudSource | https://www.sutherlandcloudsource.com |
 SweetRush | http://www.sweetrush.com |
 Sysdig | http://www.sysdig.org/ |
 Tag1 Consulting | https://tag1consulting.com/ | Worldwide

--- a/bin/rename.sh
+++ b/bin/rename.sh
@@ -15,4 +15,4 @@ fi
 
 git mv "$old_name" "$new_name"
 
-sed -i "s#/$old_name#/$new_name#" README.md
+sed -i "s#/$old_name#/$new_name#" README.md "$new_name"

--- a/bin/validate.js
+++ b/bin/validate.js
@@ -36,6 +36,18 @@ const headingsOptional = [
 
 
 /**
+ * Utility functions
+ */
+
+function companyNameToProfileFilename( companyName ) {
+	return companyName.toLowerCase()
+		.replace( /&/g, ' and ' )
+		.replace( /[^a-z0-9]+/gi, '-' )
+		.replace( /^-|-$/g, '' );
+}
+
+
+/**
  * Build list of Markdown files containing company profiles.
  */
 
@@ -81,7 +93,7 @@ $( 'tr' ).each( ( i, tr ) => {
 	}
 
 	const entry = {
-		name: $td.eq( 0 ).text(),
+		name: $td.eq( 0 ).text().replace( '\u26a0', '' ).trim(),
 		website: $td.eq( 1 ).text(),
 		shortRegion: $td.eq( 2 ).text(),
 	};
@@ -127,11 +139,20 @@ $( 'tr' ).each( ( i, tr ) => {
 			);
 		}
 	} else {
-		// We're not ready to do this check yet!
-		/* readmeError(
-			'Company "%s" has no linked Markdown profile',
-			entry.name
-		); */
+		process.stdout.write( require( 'util' ).format(
+			's#^%s |#[%s](/company-profiles/%s.md) %s |#; ',
+			entry.name,
+			entry.name,
+			companyNameToProfileFilename( entry.name ),
+			'\u26a0' // warning sign
+		) );
+		/*
+		readmeError(
+			'Company "%s" has no linked Markdown profile ("%s.md")',
+			entry.name,
+			companyNameToProfileFilename( entry.name )
+		);
+		*/
 	}
 
 	readmeCompanies.push( entry );
@@ -176,10 +197,7 @@ profileFilenames.forEach( filename => {
 	}
 
 	const filenameBase = filename.replace( /\.md$/, '' );
-	const filenameExpected = companyName.toLowerCase()
-		.replace( /&/g, ' and ' )
-		.replace( /[^a-z0-9]+/gi, '-' )
-		.replace( /^-|-$/g, '' );
+	const filenameExpected = companyNameToProfileFilename( companyName );
 	if (
 		filenameBase !== filenameExpected &&
 		// Some profile files just have shorter names than the company name,

--- a/bin/validate.js
+++ b/bin/validate.js
@@ -125,6 +125,27 @@ $( 'tr' ).each( ( i, tr ) => {
 		if ( match ) {
 			entry.linkedFilename = match[ 1 ];
 			if ( profileFilenames.indexOf( entry.linkedFilename ) === -1 ) {
+				const profileFilename = companyNameToProfileFilename( entry.name ) + '.md';
+				fs.writeFileSync(
+					path.join( profilesPath, profileFilename ),
+					require( 'util' ).format(
+						[
+							'# %s',
+							'',
+							'## Company blurb',
+							'',
+							"\u26a0 We don't have much information about this company yet!",
+							'',
+							"If you know something we don't, help us fill it in!  Here's how:",
+							'',
+							'- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)',
+							'- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)',
+							'- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/%s)',
+						].join( '\n' ) + '\n',
+						entry.name,
+						profileFilename
+					)
+				);
 				readmeError(
 					'Broken link to company "%s": "%s"',
 					entry.name,
@@ -139,20 +160,11 @@ $( 'tr' ).each( ( i, tr ) => {
 			);
 		}
 	} else {
-		process.stdout.write( require( 'util' ).format(
-			's#^%s |#[%s](/company-profiles/%s.md) %s |#; ',
-			entry.name,
-			entry.name,
-			companyNameToProfileFilename( entry.name ),
-			'\u26a0' // warning sign
-		) );
-		/*
 		readmeError(
 			'Company "%s" has no linked Markdown profile ("%s.md")',
 			entry.name,
 			companyNameToProfileFilename( entry.name )
 		);
-		*/
 	}
 
 	readmeCompanies.push( entry );

--- a/bin/validate.js
+++ b/bin/validate.js
@@ -125,27 +125,6 @@ $( 'tr' ).each( ( i, tr ) => {
 		if ( match ) {
 			entry.linkedFilename = match[ 1 ];
 			if ( profileFilenames.indexOf( entry.linkedFilename ) === -1 ) {
-				const profileFilename = companyNameToProfileFilename( entry.name ) + '.md';
-				fs.writeFileSync(
-					path.join( profilesPath, profileFilename ),
-					require( 'util' ).format(
-						[
-							'# %s',
-							'',
-							'## Company blurb',
-							'',
-							"\u26a0 We don't have much information about this company yet!",
-							'',
-							"If you know something we don't, help us fill it in!  Here's how:",
-							'',
-							'- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)',
-							'- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)',
-							'- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/%s)',
-						].join( '\n' ) + '\n',
-						entry.name,
-						profileFilename
-					)
-				);
 				readmeError(
 					'Broken link to company "%s": "%s"',
 					entry.name,

--- a/company-profiles/45royale.md
+++ b/company-profiles/45royale.md
@@ -1,0 +1,11 @@
+# 45royale
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/45royale.md)

--- a/company-profiles/aerolab.md
+++ b/company-profiles/aerolab.md
@@ -1,0 +1,11 @@
+# Aerolab
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/aerolab.md)

--- a/company-profiles/angularclass.md
+++ b/company-profiles/angularclass.md
@@ -1,0 +1,11 @@
+# AngularClass
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/angularclass.md)

--- a/company-profiles/anomali.md
+++ b/company-profiles/anomali.md
@@ -1,0 +1,11 @@
+# Anomali
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/anomali.md)

--- a/company-profiles/appendto.md
+++ b/company-profiles/appendto.md
@@ -1,0 +1,11 @@
+# appendTo
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/appendto.md)

--- a/company-profiles/arkency.md
+++ b/company-profiles/arkency.md
@@ -1,0 +1,11 @@
+# Arkency
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/arkency.md)

--- a/company-profiles/audiense.md
+++ b/company-profiles/audiense.md
@@ -1,0 +1,11 @@
+# Audiense
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/audiense.md)

--- a/company-profiles/azoolla.md
+++ b/company-profiles/azoolla.md
@@ -1,0 +1,11 @@
+# Azoolla
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/azoolla.md)

--- a/company-profiles/bebanjo.md
+++ b/company-profiles/bebanjo.md
@@ -1,0 +1,11 @@
+# BeBanjo
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/bebanjo.md)

--- a/company-profiles/betable.md
+++ b/company-profiles/betable.md
@@ -1,0 +1,11 @@
+# Betable
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/betable.md)

--- a/company-profiles/bizink.md
+++ b/company-profiles/bizink.md
@@ -1,0 +1,11 @@
+# Bizink
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/bizink.md)

--- a/company-profiles/black-pixel.md
+++ b/company-profiles/black-pixel.md
@@ -1,0 +1,11 @@
+# Black Pixel
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/black-pixel.md)

--- a/company-profiles/bloc.md
+++ b/company-profiles/bloc.md
@@ -1,0 +1,11 @@
+# Bloc
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/bloc.md)

--- a/company-profiles/bluespark.md
+++ b/company-profiles/bluespark.md
@@ -1,0 +1,11 @@
+# Bluespark
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/bluespark.md)

--- a/company-profiles/brave-investments.md
+++ b/company-profiles/brave-investments.md
@@ -1,0 +1,11 @@
+# Brave Investments
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/brave-investments.md)

--- a/company-profiles/bright-funds.md
+++ b/company-profiles/bright-funds.md
@@ -1,0 +1,11 @@
+# Bright Funds
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/bright-funds.md)

--- a/company-profiles/bulut-yazilim.md
+++ b/company-profiles/bulut-yazilim.md
@@ -1,0 +1,11 @@
+# Bulut Yazilim
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/bulut-yazilim.md)

--- a/company-profiles/buysellads.md
+++ b/company-profiles/buysellads.md
@@ -1,0 +1,11 @@
+# BuySellAds
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/buysellads.md)

--- a/company-profiles/carbon-black.md
+++ b/company-profiles/carbon-black.md
@@ -1,0 +1,11 @@
+# Carbon Black
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/carbon-black.md)

--- a/company-profiles/cards-against-humanity.md
+++ b/company-profiles/cards-against-humanity.md
@@ -1,0 +1,11 @@
+# Cards Against Humanity
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/cards-against-humanity.md)

--- a/company-profiles/cartstack.md
+++ b/company-profiles/cartstack.md
@@ -1,0 +1,11 @@
+# CartStack
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/cartstack.md)

--- a/company-profiles/charity-water.md
+++ b/company-profiles/charity-water.md
@@ -1,0 +1,11 @@
+# charity: water
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/charity-water.md)

--- a/company-profiles/circleci.md
+++ b/company-profiles/circleci.md
@@ -1,0 +1,11 @@
+# CircleCI
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/circleci.md)

--- a/company-profiles/codeship.md
+++ b/company-profiles/codeship.md
@@ -1,0 +1,11 @@
+# Codeship
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/codeship.md)

--- a/company-profiles/collabora.md
+++ b/company-profiles/collabora.md
@@ -1,0 +1,11 @@
+# Collabora
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/collabora.md)

--- a/company-profiles/compose.md
+++ b/company-profiles/compose.md
@@ -1,0 +1,11 @@
+# Compose
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/compose.md)

--- a/company-profiles/consumer-financial-protection-bureau.md
+++ b/company-profiles/consumer-financial-protection-bureau.md
@@ -1,0 +1,11 @@
+# Consumer Financial Protection Bureau
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/consumer-financial-protection-bureau.md)

--- a/company-profiles/continu.md
+++ b/company-profiles/continu.md
@@ -1,0 +1,11 @@
+# Continu
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/continu.md)

--- a/company-profiles/core-apps.md
+++ b/company-profiles/core-apps.md
@@ -1,0 +1,11 @@
+# Core-Apps
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/core-apps.md)

--- a/company-profiles/coreos.md
+++ b/company-profiles/coreos.md
@@ -1,0 +1,11 @@
+# CoreOS
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/coreos.md)

--- a/company-profiles/crossover.md
+++ b/company-profiles/crossover.md
@@ -1,0 +1,11 @@
+# Crossover
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/crossover.md)

--- a/company-profiles/datastax.md
+++ b/company-profiles/datastax.md
@@ -1,0 +1,11 @@
+# DataStax
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/datastax.md)

--- a/company-profiles/datica.md
+++ b/company-profiles/datica.md
@@ -1,0 +1,11 @@
+# Datica
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/datica.md)

--- a/company-profiles/dealdash.md
+++ b/company-profiles/dealdash.md
@@ -1,0 +1,11 @@
+# DealDash
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/dealdash.md)

--- a/company-profiles/delighted.md
+++ b/company-profiles/delighted.md
@@ -1,0 +1,11 @@
+# Delighted
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/delighted.md)

--- a/company-profiles/docker.md
+++ b/company-profiles/docker.md
@@ -1,0 +1,11 @@
+# Docker
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/docker.md)

--- a/company-profiles/duckduckgo.md
+++ b/company-profiles/duckduckgo.md
@@ -1,0 +1,11 @@
+# DuckDuckGo
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/duckduckgo.md)

--- a/company-profiles/engineyard-support-team.md
+++ b/company-profiles/engineyard-support-team.md
@@ -1,0 +1,11 @@
+# EngineYard (Support Team)
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/engineyard-support-team.md)

--- a/company-profiles/engineyard.md
+++ b/company-profiles/engineyard.md
@@ -1,4 +1,4 @@
-# Vox Media (Product Team)
+# EngineYard (Support Team)
 
 ## Company blurb
 
@@ -8,4 +8,4 @@ If you know something we don't, help us fill it in!  Here's how:
 
 - Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
 - Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
-- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/vox-media-product-team.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/engineyard.md)

--- a/company-profiles/enjoei.md
+++ b/company-profiles/enjoei.md
@@ -1,0 +1,11 @@
+# Enjoei
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/enjoei.md)

--- a/company-profiles/estately.md
+++ b/company-profiles/estately.md
@@ -1,0 +1,11 @@
+# Estately
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/estately.md)

--- a/company-profiles/evelo.md
+++ b/company-profiles/evelo.md
@@ -1,0 +1,11 @@
+# EVELO
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/evelo.md)

--- a/company-profiles/fastly.md
+++ b/company-profiles/fastly.md
@@ -1,0 +1,11 @@
+# Fastly
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/fastly.md)

--- a/company-profiles/featurist.md
+++ b/company-profiles/featurist.md
@@ -1,0 +1,11 @@
+# Featurist
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/featurist.md)

--- a/company-profiles/fetlife.md
+++ b/company-profiles/fetlife.md
@@ -1,0 +1,11 @@
+# Fetlife
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/fetlife.md)

--- a/company-profiles/filament-group.md
+++ b/company-profiles/filament-group.md
@@ -1,0 +1,11 @@
+# Filament Group
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/filament-group.md)

--- a/company-profiles/fire-engine-red.md
+++ b/company-profiles/fire-engine-red.md
@@ -1,0 +1,11 @@
+# Fire Engine Red
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/fire-engine-red.md)

--- a/company-profiles/focusnetworks.md
+++ b/company-profiles/focusnetworks.md
@@ -1,0 +1,11 @@
+# Focusnetworks
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/focusnetworks.md)

--- a/company-profiles/four-kitchens.md
+++ b/company-profiles/four-kitchens.md
@@ -1,0 +1,11 @@
+# Four Kitchens
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/four-kitchens.md)

--- a/company-profiles/fournova.md
+++ b/company-profiles/fournova.md
@@ -1,0 +1,11 @@
+# fournova
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/fournova.md)

--- a/company-profiles/geckoboard.md
+++ b/company-profiles/geckoboard.md
@@ -1,0 +1,11 @@
+# Geckoboard
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/geckoboard.md)

--- a/company-profiles/general-assembly.md
+++ b/company-profiles/general-assembly.md
@@ -1,0 +1,11 @@
+# General Assembly
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/general-assembly.md)

--- a/company-profiles/giant-swarm.md
+++ b/company-profiles/giant-swarm.md
@@ -1,0 +1,11 @@
+# Giant Swarm
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/giant-swarm.md)

--- a/company-profiles/gitbook.md
+++ b/company-profiles/gitbook.md
@@ -1,0 +1,11 @@
+# Gitbook
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/gitbook.md)

--- a/company-profiles/gitlab.md
+++ b/company-profiles/gitlab.md
@@ -1,0 +1,11 @@
+# GitLab
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/gitlab.md)

--- a/company-profiles/glue-networks.md
+++ b/company-profiles/glue-networks.md
@@ -1,0 +1,11 @@
+# Glue Networks
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/glue-networks.md)

--- a/company-profiles/gohiring.md
+++ b/company-profiles/gohiring.md
@@ -1,0 +1,11 @@
+# GoHiring
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/gohiring.md)

--- a/company-profiles/gotsoccer-llc.md
+++ b/company-profiles/gotsoccer-llc.md
@@ -1,0 +1,11 @@
+# GotSoccer, LLC
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/gotsoccer-llc.md)

--- a/company-profiles/graylog.md
+++ b/company-profiles/graylog.md
@@ -1,0 +1,11 @@
+# Graylog
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/graylog.md)

--- a/company-profiles/haiku-learning.md
+++ b/company-profiles/haiku-learning.md
@@ -1,0 +1,11 @@
+# Haiku Learning
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/haiku-learning.md)

--- a/company-profiles/hanno.md
+++ b/company-profiles/hanno.md
@@ -1,0 +1,11 @@
+# Hanno
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/hanno.md)

--- a/company-profiles/happy-cog.md
+++ b/company-profiles/happy-cog.md
@@ -1,0 +1,11 @@
+# Happy Cog
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/happy-cog.md)

--- a/company-profiles/hashicorp.md
+++ b/company-profiles/hashicorp.md
@@ -1,0 +1,11 @@
+# HashiCorp
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/hashicorp.md)

--- a/company-profiles/healthfinch.md
+++ b/company-profiles/healthfinch.md
@@ -1,0 +1,11 @@
+# Healthfinch
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/healthfinch.md)

--- a/company-profiles/help-scout.md
+++ b/company-profiles/help-scout.md
@@ -1,0 +1,11 @@
+# Help Scout
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/help-scout.md)

--- a/company-profiles/heroku.md
+++ b/company-profiles/heroku.md
@@ -1,0 +1,11 @@
+# Heroku
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/heroku.md)

--- a/company-profiles/honeybadger.md
+++ b/company-profiles/honeybadger.md
@@ -1,0 +1,11 @@
+# Honeybadger
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/honeybadger.md)

--- a/company-profiles/hotjar.md
+++ b/company-profiles/hotjar.md
@@ -1,0 +1,11 @@
+# Hotjar
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/hotjar.md)

--- a/company-profiles/idonethis.md
+++ b/company-profiles/idonethis.md
@@ -1,0 +1,11 @@
+# IDoneThis
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/idonethis.md)

--- a/company-profiles/igalia.md
+++ b/company-profiles/igalia.md
@@ -1,0 +1,11 @@
+# Igalia
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/igalia.md)

--- a/company-profiles/influxdata.md
+++ b/company-profiles/influxdata.md
@@ -1,0 +1,11 @@
+# InfluxData
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/influxdata.md)

--- a/company-profiles/inpsyde.md
+++ b/company-profiles/inpsyde.md
@@ -1,0 +1,11 @@
+# Inpsyde
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/inpsyde.md)

--- a/company-profiles/intellum.md
+++ b/company-profiles/intellum.md
@@ -1,0 +1,11 @@
+# Intellum
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/intellum.md)

--- a/company-profiles/interpersonal-frequency-i-f.md
+++ b/company-profiles/interpersonal-frequency-i-f.md
@@ -1,0 +1,11 @@
+# Interpersonal Frequency (I.F.)
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/interpersonal-frequency-i-f.md)

--- a/company-profiles/invision.md
+++ b/company-profiles/invision.md
@@ -1,0 +1,11 @@
+# InVision
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/invision.md)

--- a/company-profiles/ips-group-inc.md
+++ b/company-profiles/ips-group-inc.md
@@ -1,0 +1,11 @@
+# IPS Group, Inc.
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/ips-group-inc.md)

--- a/company-profiles/jolly-good-code.md
+++ b/company-profiles/jolly-good-code.md
@@ -1,0 +1,11 @@
+# Jolly Good Code
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/jolly-good-code.md)

--- a/company-profiles/keen-io.md
+++ b/company-profiles/keen-io.md
@@ -1,0 +1,11 @@
+# Keen IO
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/keen-io.md)

--- a/company-profiles/khan-academy.md
+++ b/company-profiles/khan-academy.md
@@ -1,0 +1,11 @@
+# Khan Academy
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/khan-academy.md)

--- a/company-profiles/kickback-rewards-systems.md
+++ b/company-profiles/kickback-rewards-systems.md
@@ -1,0 +1,11 @@
+# KickBack Rewards Systems
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/kickback-rewards-systems.md)

--- a/company-profiles/koding.md
+++ b/company-profiles/koding.md
@@ -1,0 +1,11 @@
+# Koding
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/koding.md)

--- a/company-profiles/librato.md
+++ b/company-profiles/librato.md
@@ -1,0 +1,11 @@
+# Librato
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/librato.md)

--- a/company-profiles/lightbend.md
+++ b/company-profiles/lightbend.md
@@ -1,0 +1,11 @@
+# Lightbend
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/lightbend.md)

--- a/company-profiles/linaro.md
+++ b/company-profiles/linaro.md
@@ -1,0 +1,11 @@
+# Linaro
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/linaro.md)

--- a/company-profiles/lincoln-loop.md
+++ b/company-profiles/lincoln-loop.md
@@ -1,0 +1,11 @@
+# Lincoln Loop
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/lincoln-loop.md)

--- a/company-profiles/linux-foundation.md
+++ b/company-profiles/linux-foundation.md
@@ -1,0 +1,11 @@
+# Linux Foundation
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/linux-foundation.md)

--- a/company-profiles/livingsocial.md
+++ b/company-profiles/livingsocial.md
@@ -1,0 +1,11 @@
+# LivingSocial
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/livingsocial.md)

--- a/company-profiles/marketade.md
+++ b/company-profiles/marketade.md
@@ -1,0 +1,11 @@
+# Marketade
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/marketade.md)

--- a/company-profiles/memberful.md
+++ b/company-profiles/memberful.md
@@ -1,0 +1,11 @@
+# Memberful
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/memberful.md)

--- a/company-profiles/metalab.md
+++ b/company-profiles/metalab.md
@@ -1,0 +1,11 @@
+# MetaLab
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/metalab.md)

--- a/company-profiles/mixcloud.md
+++ b/company-profiles/mixcloud.md
@@ -1,0 +1,11 @@
+# Mixcloud
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/mixcloud.md)

--- a/company-profiles/mokriya.md
+++ b/company-profiles/mokriya.md
@@ -1,0 +1,11 @@
+# Mokriya
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/mokriya.md)

--- a/company-profiles/mozilla.md
+++ b/company-profiles/mozilla.md
@@ -1,0 +1,11 @@
+# Mozilla
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/mozilla.md)

--- a/company-profiles/mycelium.md
+++ b/company-profiles/mycelium.md
@@ -1,0 +1,11 @@
+# Mycelium
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/mycelium.md)

--- a/company-profiles/mysql.md
+++ b/company-profiles/mysql.md
@@ -1,0 +1,11 @@
+# MySQL
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/mysql.md)

--- a/company-profiles/netguru.md
+++ b/company-profiles/netguru.md
@@ -1,0 +1,11 @@
+# Netguru
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/netguru.md)

--- a/company-profiles/next-big-sound.md
+++ b/company-profiles/next-big-sound.md
@@ -1,0 +1,11 @@
+# Next Big Sound
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/next-big-sound.md)

--- a/company-profiles/npm.md
+++ b/company-profiles/npm.md
@@ -1,0 +1,11 @@
+# npm
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/npm.md)

--- a/company-profiles/o-reilly-media.md
+++ b/company-profiles/o-reilly-media.md
@@ -1,0 +1,11 @@
+# O'Reilly Media
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/o-reilly-media.md)

--- a/company-profiles/opencraft.md
+++ b/company-profiles/opencraft.md
@@ -1,0 +1,11 @@
+# OpenCraft
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/opencraft.md)

--- a/company-profiles/oracle.md
+++ b/company-profiles/oracle.md
@@ -1,0 +1,11 @@
+# Oracle
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/oracle.md)

--- a/company-profiles/our-hometown-inc.md
+++ b/company-profiles/our-hometown-inc.md
@@ -1,0 +1,11 @@
+# Our-Hometown Inc.
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/our-hometown-inc.md)

--- a/company-profiles/parker-wallace.md
+++ b/company-profiles/parker-wallace.md
@@ -1,0 +1,11 @@
+# Parker Wallace
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/parker-wallace.md)

--- a/company-profiles/parsely.md
+++ b/company-profiles/parsely.md
@@ -1,0 +1,11 @@
+# Parsely
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/parsely.md)

--- a/company-profiles/particular-software.md
+++ b/company-profiles/particular-software.md
@@ -1,0 +1,11 @@
+# Particular Software
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/particular-software.md)

--- a/company-profiles/pathable.md
+++ b/company-profiles/pathable.md
@@ -1,0 +1,11 @@
+# Pathable
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/pathable.md)

--- a/company-profiles/paylocity.md
+++ b/company-profiles/paylocity.md
@@ -1,0 +1,11 @@
+# Paylocity
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/paylocity.md)

--- a/company-profiles/peachworks.md
+++ b/company-profiles/peachworks.md
@@ -1,0 +1,11 @@
+# PeachWorks
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/peachworks.md)

--- a/company-profiles/pelagicore.md
+++ b/company-profiles/pelagicore.md
@@ -1,0 +1,11 @@
+# Pelagicore
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/pelagicore.md)

--- a/company-profiles/peopledoc.md
+++ b/company-profiles/peopledoc.md
@@ -1,0 +1,11 @@
+# PeopleDoc
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/peopledoc.md)

--- a/company-profiles/precision-nutrition.md
+++ b/company-profiles/precision-nutrition.md
@@ -1,0 +1,11 @@
+# Precision Nutrition
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/precision-nutrition.md)

--- a/company-profiles/previousnext.md
+++ b/company-profiles/previousnext.md
@@ -1,0 +1,11 @@
+# PreviousNext
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/previousnext.md)

--- a/company-profiles/rainforest-qa.md
+++ b/company-profiles/rainforest-qa.md
@@ -1,0 +1,11 @@
+# Rainforest QA
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/rainforest-qa.md)

--- a/company-profiles/realhq.md
+++ b/company-profiles/realhq.md
@@ -1,0 +1,11 @@
+# RealHQ
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/realhq.md)

--- a/company-profiles/rebelmouse.md
+++ b/company-profiles/rebelmouse.md
@@ -1,0 +1,11 @@
+# RebelMouse
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/rebelmouse.md)

--- a/company-profiles/receiptful.md
+++ b/company-profiles/receiptful.md
@@ -1,0 +1,11 @@
+# Receiptful
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/receiptful.md)

--- a/company-profiles/recurly.md
+++ b/company-profiles/recurly.md
@@ -1,0 +1,11 @@
+# Recurly
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/recurly.md)

--- a/company-profiles/redmonk.md
+++ b/company-profiles/redmonk.md
@@ -1,0 +1,11 @@
+# RedMonk
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/redmonk.md)

--- a/company-profiles/reinteractive.md
+++ b/company-profiles/reinteractive.md
@@ -1,0 +1,11 @@
+# reinteractive
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/reinteractive.md)

--- a/company-profiles/research-square.md
+++ b/company-profiles/research-square.md
@@ -1,0 +1,11 @@
+# Research Square
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/research-square.md)

--- a/company-profiles/rightscale.md
+++ b/company-profiles/rightscale.md
@@ -1,0 +1,11 @@
+# RightScale
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/rightscale.md)

--- a/company-profiles/safari-books-online.md
+++ b/company-profiles/safari-books-online.md
@@ -1,0 +1,11 @@
+# Safari Books Online
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/safari-books-online.md)

--- a/company-profiles/salesforce.md
+++ b/company-profiles/salesforce.md
@@ -1,0 +1,11 @@
+# Salesforce
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/salesforce.md)

--- a/company-profiles/sawhorse-media.md
+++ b/company-profiles/sawhorse-media.md
@@ -1,0 +1,11 @@
+# Sawhorse Media
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/sawhorse-media.md)

--- a/company-profiles/scrapinghub.md
+++ b/company-profiles/scrapinghub.md
@@ -1,0 +1,11 @@
+# Scrapinghub
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/scrapinghub.md)

--- a/company-profiles/securityscorecard.md
+++ b/company-profiles/securityscorecard.md
@@ -1,0 +1,11 @@
+# SecurityScorecard
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/securityscorecard.md)

--- a/company-profiles/seed.md
+++ b/company-profiles/seed.md
@@ -1,0 +1,11 @@
+# SEED
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/seed.md)

--- a/company-profiles/signeasy.md
+++ b/company-profiles/signeasy.md
@@ -1,0 +1,11 @@
+# SignEasy
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/signeasy.md)

--- a/company-profiles/skillshare.md
+++ b/company-profiles/skillshare.md
@@ -1,0 +1,11 @@
+# Skillshare
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/skillshare.md)

--- a/company-profiles/smugmug.md
+++ b/company-profiles/smugmug.md
@@ -1,0 +1,11 @@
+# SmugMug
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/smugmug.md)

--- a/company-profiles/softwaremill.md
+++ b/company-profiles/softwaremill.md
@@ -1,0 +1,11 @@
+# SoftwareMill
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/softwaremill.md)

--- a/company-profiles/soostone.md
+++ b/company-profiles/soostone.md
@@ -1,0 +1,11 @@
+# Soostone
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/soostone.md)

--- a/company-profiles/stitch-fix.md
+++ b/company-profiles/stitch-fix.md
@@ -1,0 +1,11 @@
+# Stitch Fix
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/stitch-fix.md)

--- a/company-profiles/strongloop.md
+++ b/company-profiles/strongloop.md
@@ -1,0 +1,11 @@
+# Strongloop
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/strongloop.md)

--- a/company-profiles/surevine.md
+++ b/company-profiles/surevine.md
@@ -1,0 +1,11 @@
+# Surevine
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/surevine.md)

--- a/company-profiles/suse.md
+++ b/company-profiles/suse.md
@@ -1,0 +1,11 @@
+# SUSE
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/suse.md)

--- a/company-profiles/sutherland-cloudsource.md
+++ b/company-profiles/sutherland-cloudsource.md
@@ -1,0 +1,11 @@
+# Sutherland CloudSource
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/sutherland-cloudsource.md)

--- a/company-profiles/sweetrush.md
+++ b/company-profiles/sweetrush.md
@@ -1,0 +1,11 @@
+# SweetRush
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/sweetrush.md)

--- a/company-profiles/sysdig.md
+++ b/company-profiles/sysdig.md
@@ -1,0 +1,11 @@
+# Sysdig
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/sysdig.md)

--- a/company-profiles/tag1-consulting.md
+++ b/company-profiles/tag1-consulting.md
@@ -1,0 +1,11 @@
+# Tag1 Consulting
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/tag1-consulting.md)

--- a/company-profiles/taplytics.md
+++ b/company-profiles/taplytics.md
@@ -1,0 +1,11 @@
+# Taplytics
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/taplytics.md)

--- a/company-profiles/teamed.md
+++ b/company-profiles/teamed.md
@@ -1,0 +1,11 @@
+# teamed.
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/teamed.md)

--- a/company-profiles/teamsnap.md
+++ b/company-profiles/teamsnap.md
@@ -1,0 +1,11 @@
+# TeamSnap
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/teamsnap.md)

--- a/company-profiles/ted.md
+++ b/company-profiles/ted.md
@@ -1,0 +1,11 @@
+# TED
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/ted.md)

--- a/company-profiles/teleport.md
+++ b/company-profiles/teleport.md
@@ -1,0 +1,11 @@
+# Teleport
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/teleport.md)

--- a/company-profiles/telerik.md
+++ b/company-profiles/telerik.md
@@ -1,0 +1,11 @@
+# Telerik
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/telerik.md)

--- a/company-profiles/tenable.md
+++ b/company-profiles/tenable.md
@@ -1,0 +1,11 @@
+# Tenable
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/tenable.md)

--- a/company-profiles/test-double.md
+++ b/company-profiles/test-double.md
@@ -1,0 +1,11 @@
+# Test Double
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/test-double.md)

--- a/company-profiles/the-publisher-desk.md
+++ b/company-profiles/the-publisher-desk.md
@@ -1,0 +1,11 @@
+# The Publisher Desk
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/the-publisher-desk.md)

--- a/company-profiles/the-remote-lab.md
+++ b/company-profiles/the-remote-lab.md
@@ -1,0 +1,11 @@
+# The Remote Lab
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/the-remote-lab.md)

--- a/company-profiles/tidy-homekeeping.md
+++ b/company-profiles/tidy-homekeeping.md
@@ -1,0 +1,11 @@
+# TIDY Homekeeping
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/tidy-homekeeping.md)

--- a/company-profiles/tractionboard.md
+++ b/company-profiles/tractionboard.md
@@ -1,0 +1,11 @@
+# Tractionboard
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/tractionboard.md)

--- a/company-profiles/travis-ci.md
+++ b/company-profiles/travis-ci.md
@@ -1,0 +1,11 @@
+# Travis CI
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/travis-ci.md)

--- a/company-profiles/trello.md
+++ b/company-profiles/trello.md
@@ -1,0 +1,11 @@
+# Trello
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/trello.md)

--- a/company-profiles/twin-technologies.md
+++ b/company-profiles/twin-technologies.md
@@ -1,0 +1,11 @@
+# Twin Technologies
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/twin-technologies.md)

--- a/company-profiles/uptrending.md
+++ b/company-profiles/uptrending.md
@@ -1,0 +1,11 @@
+# UpTrending
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/uptrending.md)

--- a/company-profiles/upwork-pro.md
+++ b/company-profiles/upwork-pro.md
@@ -1,0 +1,11 @@
+# Upwork Pro
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/upwork-pro.md)

--- a/company-profiles/upworthy.md
+++ b/company-profiles/upworthy.md
@@ -1,0 +1,11 @@
+# Upworthy
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/upworthy.md)

--- a/company-profiles/varnish-software.md
+++ b/company-profiles/varnish-software.md
@@ -1,0 +1,11 @@
+# Varnish Software
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/varnish-software.md)

--- a/company-profiles/vox-media-product-team.md
+++ b/company-profiles/vox-media-product-team.md
@@ -1,0 +1,11 @@
+# Vox Media (Product Team)
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/vox-media-product-team.md)

--- a/company-profiles/vox-media.md
+++ b/company-profiles/vox-media.md
@@ -1,4 +1,4 @@
-# EngineYard (Support Team)
+# Vox Media (Product Team)
 
 ## Company blurb
 
@@ -8,4 +8,4 @@ If you know something we don't, help us fill it in!  Here's how:
 
 - Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
 - Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
-- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/engineyard-support-team.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/vox-media.md)

--- a/company-profiles/webdevstudios.md
+++ b/company-profiles/webdevstudios.md
@@ -1,0 +1,11 @@
+# WebDevStudios
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/webdevstudios.md)

--- a/company-profiles/wellmatch.md
+++ b/company-profiles/wellmatch.md
@@ -1,0 +1,11 @@
+# WellMatch
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/wellmatch.md)

--- a/company-profiles/whitecap-seo.md
+++ b/company-profiles/whitecap-seo.md
@@ -1,0 +1,11 @@
+# Whitecap SEO
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/whitecap-seo.md)

--- a/company-profiles/whitespectre.md
+++ b/company-profiles/whitespectre.md
@@ -1,0 +1,11 @@
+# Whitespectre
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/whitespectre.md)

--- a/company-profiles/wikihow.md
+++ b/company-profiles/wikihow.md
@@ -1,0 +1,11 @@
+# WikiHow
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/wikihow.md)

--- a/company-profiles/wombat-security-technologies.md
+++ b/company-profiles/wombat-security-technologies.md
@@ -1,0 +1,11 @@
+# Wombat Security Technologies
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/wombat-security-technologies.md)

--- a/company-profiles/wombat-security.md
+++ b/company-profiles/wombat-security.md
@@ -8,4 +8,4 @@ If you know something we don't, help us fill it in!  Here's how:
 
 - Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
 - Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
-- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/wombat-security-technologies.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/wombat-security.md)

--- a/company-profiles/word-to-the-wise.md
+++ b/company-profiles/word-to-the-wise.md
@@ -1,0 +1,11 @@
+# Word to the Wise
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/word-to-the-wise.md)

--- a/company-profiles/x-team.md
+++ b/company-profiles/x-team.md
@@ -1,0 +1,11 @@
+# X-Team
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/x-team.md)

--- a/company-profiles/yonder.md
+++ b/company-profiles/yonder.md
@@ -1,0 +1,11 @@
+# Yonder
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/yonder.md)

--- a/company-profiles/youcanbook-me-ltd.md
+++ b/company-profiles/youcanbook-me-ltd.md
@@ -1,0 +1,11 @@
+# YouCanBook.me Ltd
+
+## Company blurb
+
+⚠ We don't have much information about this company yet!
+
+If you know something we don't, help us fill it in!  Here's how:
+
+- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
+- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/youcanbook-me-ltd.md)

--- a/company-profiles/youcanbook-me.md
+++ b/company-profiles/youcanbook-me.md
@@ -8,4 +8,4 @@ If you know something we don't, help us fill it in!  Here's how:
 
 - Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
 - Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
-- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/youcanbook-me-ltd.md)
+- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/youcanbook-me.md)


### PR DESCRIPTION
This PR adds minimal Markdown profile files for all companies in the readme and requires all newly added companies to have a profile as part of the automatic validation.

Companies with the newly added minimal profiles are marked with :warning: in the readme and in the profile text.  The profile text explains how to update the profile on GitHub and links to the "edit this file" interface (these links will start working after this PR is merged).

@dougaitken - anything else we should include in the minimal profiles?  Here's how they look right now:

> # 45royale
>
> ## Company blurb
>
> ⚠ We don't have much information about this company yet!
>
> If you know something we don't, help us fill it in!  Here's how:
>
> - Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
> - Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
> - Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/45royale.md)