### PR TITLE
Add Nuna Inc to listing of remote jobs

### DIFF
--- a/PULL_REQUEST_TEMPLATE.MD
+++ b/PULL_REQUEST_TEMPLATE.MD
@@ -2,12 +2,12 @@ This is a modified version of the [Contributing Guidelines](https://github.com/r
 
 This pull request adheres to the repository's [Code of Conduct](https://github.com/remoteintech/remote-jobs/blob/master/CODE_OF_CONDUCT.md).
 
-- [ ] I am an employee of the company mentioned and confirm all included details are correct
-- [ ] This PR contains housekeeping only (URL edits, copy changes etc)
-- [ ] You know your alphabet - company is listed in alphabetical order in the README
-- [ ] The company directly hires employees. No bootcamps / freelance sites / etc
-- [ ] The company added hires remote employees, or positions are available to remote workers and are clearly illustrated as such
-- [ ] A [company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md) is included - __Required__ for new additions. (This can be a basic outline but at least something please)
-- [ ] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
-- [ ] __Region__ details any restrictions to applicants based on geography
-- [ ] __How to apply__ details the best approach for new applications, page on site where open position are listed, and any other help available for job hunters
+- [x] I am an employee of the company mentioned and confirm all included details are correct
+- [x] This PR contains housekeeping only (URL edits, copy changes etc)
+- [x] You know your alphabet - company is listed in alphabetical order in the README
+- [x] The company directly hires employees. No bootcamps / freelance sites / etc
+- [x] The company added hires remote employees, or positions are available to remote workers and are clearly illustrated as such
+- [x] A [company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/nuna.md) is included - __Required__ for new additions. (This can be a basic outline but at least something please)
+- [x] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
+- [x] __Region__ details any restrictions to applicants based on geography
+- [x] __How to apply__ details the best approach for new applications, page on site where open position are listed, and any other help available for job hunters

--- a/PULL_REQUEST_TEMPLATE.MD
+++ b/PULL_REQUEST_TEMPLATE.MD
@@ -2,12 +2,12 @@ This is a modified version of the [Contributing Guidelines](https://github.com/r
 
 This pull request adheres to the repository's [Code of Conduct](https://github.com/remoteintech/remote-jobs/blob/master/CODE_OF_CONDUCT.md).
 
-- [x] I am an employee of the company mentioned and confirm all included details are correct
-- [x] This PR contains housekeeping only (URL edits, copy changes etc)
-- [x] You know your alphabet - company is listed in alphabetical order in the README
-- [x] The company directly hires employees. No bootcamps / freelance sites / etc
-- [x] The company added hires remote employees, or positions are available to remote workers and are clearly illustrated as such
-- [x] A [company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/nuna.md) is included - __Required__ for new additions. (This can be a basic outline but at least something please)
-- [x] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
-- [x] __Region__ details any restrictions to applicants based on geography
-- [x] __How to apply__ details the best approach for new applications, page on site where open position are listed, and any other help available for job hunters
+- [ ] I am an employee of the company mentioned and confirm all included details are correct
+- [ ] This PR contains housekeeping only (URL edits, copy changes etc)
+- [ ] You know your alphabet - company is listed in alphabetical order in the README
+- [ ] The company directly hires employees. No bootcamps / freelance sites / etc
+- [ ] The company added hires remote employees, or positions are available to remote workers and are clearly illustrated as such
+- [ ] A [company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md) is included - __Required__ for new additions. (This can be a basic outline but at least something please)
+- [ ] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
+- [ ] __Region__ details any restrictions to applicants based on geography
+- [ ] __How to apply__ details the best approach for new applications, page on site where open position are listed, and any other help available for job hunters

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Name | Website | Region
 [NoRedInk](/company-profiles/noredink.md) | https://noredink.com | UTC-8 to UTC+1
 [Novoda](/company-profiles/novoda.md) | https://www.novoda.com/ | UK & Europe
 [npm](/company-profiles/npm.md) ⚠ | https://www.npmjs.com/ |
-[Nuna](/company-profiles/nuna.md) | https://www.nuna.com/ |
+[Nuna](/company-profiles/nuna.md) | https://www.nuna.com/ | US
 [O'Reilly Media](/company-profiles/o-reilly-media.md) ⚠ | http://www.oreilly.com/ |
 [Oddball](/company-profiles/oddball.md) | https://oddball.io/ | US
 [Olark](/company-profiles/olark.md) | https://www.olark.com/ | UTC-8 to UTC+1

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Name | Website | Region
 [NoRedInk](/company-profiles/noredink.md) | https://noredink.com | UTC-8 to UTC+1
 [Novoda](/company-profiles/novoda.md) | https://www.novoda.com/ | UK & Europe
 [npm](/company-profiles/npm.md) ⚠ | https://www.npmjs.com/ |
-[Nuna](/company-profiles/nuna.md) ⚠ | https://www.nuna.com/ |
+[Nuna](/company-profiles/nuna.md) | https://www.nuna.com/ |
 [O'Reilly Media](/company-profiles/o-reilly-media.md) ⚠ | http://www.oreilly.com/ |
 [Oddball](/company-profiles/oddball.md) | https://oddball.io/ | US
 [Olark](/company-profiles/olark.md) | https://www.olark.com/ | UTC-8 to UTC+1

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Name | Website | Region
 [NoRedInk](/company-profiles/noredink.md) | https://noredink.com | UTC-8 to UTC+1
 [Novoda](/company-profiles/novoda.md) | https://www.novoda.com/ | UK & Europe
 [npm](/company-profiles/npm.md) ⚠ | https://www.npmjs.com/ |
+[Nuna](/company-profiles/nuna.md) ⚠ | https://www.nuna.com/ |
 [O'Reilly Media](/company-profiles/o-reilly-media.md) ⚠ | http://www.oreilly.com/ |
 [Oddball](/company-profiles/oddball.md) | https://oddball.io/ | US
 [Olark](/company-profiles/olark.md) | https://www.olark.com/ | UTC-8 to UTC+1

--- a/company-profiles/nuna.md
+++ b/company-profiles/nuna.md
@@ -1,0 +1,31 @@
+# Nuna Inc
+
+## Company blurb
+At [Nuna](https://www.nuna.com), our mission is to make high-quality healthcare affordable for everyone. We’re dedicated to tackling one of our nation’s biggest problems with ingenuity, creativity, and a keen moral compass.
+
+Nuna builds data platforms and analytics solutions to help healthcare decision-makers like government programs, large employers, and health plans understand cost and quality trends. With these insights, they can make changes that increase access to effective, affordable care. We have a deep bench of engineering, data science, design, and policy expertise under one roof, which lets us serve as a one-stop problem solving shop.
+
+## Company size
+100-200
+
+## Remote status
+Supporting a healthy remote culture requires investment and iteration and Nuna has made a commitment to both. Three core areas that make a huge impact on remote success: 
+
+* Communication: To get our work done - and connected to one another in community - we use a variety of technologies.  From video conferencing, to Slack, to JIRA, we equip all Nunas with the tools to share, get feedback, and feel part of the team. 
+* Remote Leadership: Remote leaders make great advocates for remote culture because they reinforce habits that build a healthy remote culture. The team naturally gravitates towards remote-first practices, even if some of them sit next to each other in the office.
+* In-person meet-ups:  There’s no replacement for face-to-face time with others. Understanding that personal connections with others are crucial, Nuna holds a yearly offsite retreat for the entire company. Individual teams within the company can meet in person more frequently, and Nuna supports flying individuals to the office at least once per quarter.
+
+## Region
+Nuna is headquartered in San Francisco, but approximately 20% of our team works remotely  across the U.S., including a large cohort in the D.C./Baltimore-area near government clients.  Check out [www.nuna.com/careers](www.nuna.com/careers) to see what open roles are available to remote candidates. 
+
+## Company technologies
+
+Python, Scala, Java, R, SQL, Django, & Javascript
+Spark and Hadoop
+AWS; including EC2, EBS, EMR, ELB, SNS, RDS, CloudFormation and more
+
+## Office locations
+Nuna is headquartered in San Francisco, CA.
+
+## How to apply
+[https://www.nuna.com/careers](https://www.nuna.com/careers) or [careers@nuna.com](mailto:careers@nuna.com)


### PR DESCRIPTION
Please note, I did not check "This PR contains housekeeping only (URL edits, copy changes etc)" because I would like to submit a new company profile, not update an existing one.  Hope that's correct.

This pull request adheres to the repository's [Code of Conduct](https://github.com/remoteintech/remote-jobs/blob/master/CODE_OF_CONDUCT.md).

- [x] I am an employee of the company mentioned and confirm all included details are correct
- [] This PR contains housekeeping only (URL edits, copy changes etc)
- [x] You know your alphabet - company is listed in alphabetical order in the README
- [x] The company directly hires employees. No bootcamps / freelance sites / etc
- [x] The company added hires remote employees, or positions are available to remote workers and are clearly illustrated as such
- [x] A [company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md) is included - __Required__ for new additions. (This can be a basic outline but at least something please)
- [x] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
- [x] __Region__ details any restrictions to applicants based on geography
- [x] __How to apply__ details the best approach for new applications, page on site where open position are listed, and any other help available for job hunters
