### PR TITLE
Add GitLab company details

### DIFF
--- a/company-profiles/gitlab.md
+++ b/company-profiles/gitlab.md
@@ -2,10 +2,31 @@
 
 ## Company blurb
 
-⚠ We don't have much information about this company yet!
+[GitLab](https://about.gitlab.com/) is a single application built from the ground up for all stages of the DevOps lifecycle for Product, Development, QA, Security, and Operations teams to work concurrently on the same project. GitLab provides teams a single data store, one user interface, and one permission model across the DevOps lifecycle allowing teams to collaborate and work on a project from a single conversation, significantly reducing cycle time and focus exclusively on building great software quickly. Built on Open Source, GitLab leverages the community contributions of thousands of developers and millions of users to continuously deliver new DevOps innovations. More than 100,000 organizations from startups to global enterprise organizations, including Ticketmaster, ING, NASDAQ, Alibaba, Sony, and Intel trust GitLab to deliver great software at new speeds.
 
-If you know something we don't, help us fill it in!  Here's how:
+## Company Size
 
-- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
-- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
-- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/gitlab.md)
+[Currently 300 team members](https://about.gitlab.com/team/) and [over 2000 open source contributors](http://contributors.gitlab.com/)
+
+## Remote Status
+
+100% Remote Only.  Maintainers of [www.remoteonly.org](https://www.remoteonly.org/).  Writers of the [The Remote Manefesto](https://about.gitlab.com/2015/04/08/the-remote-manifesto/)
+
+## Region
+
+Worldwide.  We have GitLabbers on every continent (except Antartica... yet).
+
+## Company Technologies
+
+Based on the open source [GitLab](https://gitlab.com/gitlab-org/gitlab-ce/) application which was originally written in Ruby on Rails.
+
+Current GitLab technology stack includes:
+
+## Office locations
+
+No physical office...we are [100% remote only](https://about.gitlab.com/culture/remote-only/).
+
+## How to apply
+
+We are hiring! Visit [https://about.gitlab.com/jobs/](https://about.gitlab.com/jobs/)
+

--- a/company-profiles/gitlab.md
+++ b/company-profiles/gitlab.md
@@ -4,11 +4,11 @@
 
 [GitLab](https://about.gitlab.com/) is a single application built from the ground up for all stages of the DevOps lifecycle for Product, Development, QA, Security, and Operations teams to work concurrently on the same project. GitLab provides teams a single data store, one user interface, and one permission model across the DevOps lifecycle allowing teams to collaborate and work on a project from a single conversation, significantly reducing cycle time and focus exclusively on building great software quickly. Built on Open Source, GitLab leverages the community contributions of thousands of developers and millions of users to continuously deliver new DevOps innovations. More than 100,000 organizations from startups to global enterprise organizations, including Ticketmaster, ING, NASDAQ, Alibaba, Sony, and Intel trust GitLab to deliver great software at new speeds.
 
-## Company Size
+## Company size
 
 [Currently 300 team members](https://about.gitlab.com/team/) and [over 2000 open source contributors](http://contributors.gitlab.com/)
 
-## Remote Status
+## Remote status
 
 100% Remote Only.  Maintainers of [www.remoteonly.org](https://www.remoteonly.org/).  Writers of the [The Remote Manefesto](https://about.gitlab.com/2015/04/08/the-remote-manifesto/)
 
@@ -16,7 +16,7 @@
 
 Worldwide.  We have GitLabbers on every continent (except Antartica... yet).
 
-## Company Technologies
+## Company technologies
 
 Based on the open source [GitLab](https://gitlab.com/gitlab-org/gitlab-ce/) application which was originally written in Ruby on Rails.
 


### PR DESCRIPTION
This is a modified version of the [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md).

This pull request adheres to the repository's [Code of Conduct](https://github.com/remoteintech/remote-jobs/blob/master/CODE_OF_CONDUCT.md).

- [X] I am an employee of the company mentioned and confirm all included details are correct
- [ ] This PR contains housekeeping only (URL edits, copy changes etc)
- [ ] You know your alphabet - company is listed in alphabetical order in the README
- [X] The company directly hires employees. No bootcamps / freelance sites / etc
- [X] The company added hires remote employees, or positions are available to remote workers and are clearly illustrated as such
- [X] A [company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md) is included - __Required__ for new additions. (This can be a basic outline but at least something please)
- [X] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
- [X] __Region__ details any restrictions to applicants based on geography
- [X] __How to apply__ details the best approach for new applications, page on site where open position are listed, and any other help available for job hunters
