### PR TITLE
Update geckoboard region to just "Worldwide"

### DIFF
--- a/company-profiles/geckoboard.md
+++ b/company-profiles/geckoboard.md
@@ -14,7 +14,7 @@ We believe work should fit around your life, which means no overtime and the fle
 
 ## Region
 
-Worldwide, with team members across the world.
+Worldwide.
 
 ## Company technologies
 


### PR DESCRIPTION
This is a modified version of the [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md).

This pull request adheres to the repository's [Code of Conduct](https://github.com/remoteintech/remote-jobs/blob/master/CODE_OF_CONDUCT.md).

- [ ] I am an employee of the company mentioned and confirm all included details are correct
- [ ] This PR contains housekeeping only (URL edits, copy changes etc)
- [ ] You know your alphabet - company is listed in alphabetical order in the README
- [ ] The company directly hires employees. No bootcamps / freelance sites / etc
- [ ] The company added hires remote employees, or positions are available to remote workers and are clearly illustrated as such
- [ ] A [company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md) is included - __Required__ for new additions. (This can be a basic outline but at least something please)
- [ ] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
- [ ] __Region__ details any restrictions to applicants based on geography
- [ ] __How to apply__ details the best approach for new applications, page on site where open position are listed, and any other help available for job hunters
