### PR TITLE
Update region guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,10 +8,8 @@ Pull requests will be accepted based on the following:
 1. If the company is at least partially remote
 1. If you add the company in alphabetical order in the list
 1. If you submit the company with a website
-1. If you submit the company with the regions that are accepted for remote positions (US only? Worldwide? Specific timezones?) \*
+1. If you submit the company with the regions that are accepted for remote positions (for more details see the instructions in the [example company profile](/company-profiles/example.md))
 1. If you submit a company profile page and link the company name to it (see example [here](/company-profiles/example.md))
-
-\* Optional, but highly recommended
 
 Please adhere to the [Contributor Code of Conduct](CODE_OF_CONDUCT.md).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Pull requests will be accepted based on the following:
 1. If you add the company in alphabetical order in the list
 1. If you submit the company with a website
 1. If you submit the company with the regions that are accepted for remote positions (for more details see the instructions in the [example company profile](/company-profiles/example.md))
-1. If you submit a company profile page and link the company name to it (see example [here](/company-profiles/example.md))
+1. If you submit a company profile page and link the company name to it (see example [here](/company-profiles/example.md#region))
 
 Please adhere to the [Contributor Code of Conduct](CODE_OF_CONDUCT.md).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,8 @@ Pull requests will be accepted based on the following:
 1. If the company is at least partially remote
 1. If you add the company in alphabetical order in the list
 1. If you submit the company with a website
-1. If you submit the company with the regions that are accepted for remote positions (for more details see the instructions in the [example company profile](/company-profiles/example.md))
-1. If you submit a company profile page and link the company name to it (see example [here](/company-profiles/example.md#region))
+1. If you submit the company with the regions that are accepted for remote positions (for more details see the instructions in the [example company profile](/company-profiles/example.md#region))
+1. If you submit a company profile page and link the company name to it (see example [here](/company-profiles/example.md))
 
 Please adhere to the [Contributor Code of Conduct](CODE_OF_CONDUCT.md).
 

--- a/PULL_REQUEST_TEMPLATE.MD
+++ b/PULL_REQUEST_TEMPLATE.MD
@@ -9,5 +9,5 @@ This pull request adheres to the repository's [Code of Conduct](https://github.c
 - [ ] The company hires remote employees, or positions are available to remote workers and are clearly illustrated as such
 - [ ] A [company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md) is included - __Required__ for new additions. (This can be a basic outline but at least something please)
 - [ ] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
-- [ ] __Region__ details any restrictions to applicants based on geography
+- [ ] __Region__ details the geographic regions in which this company's employees can reside. For more details see the instructions in the [example company profile](/company-profiles/example.md).
 - [ ] __How to apply__ details the best approach for new applications, page on site where open position are listed, and any other help available for job hunters

--- a/PULL_REQUEST_TEMPLATE.MD
+++ b/PULL_REQUEST_TEMPLATE.MD
@@ -9,5 +9,5 @@ This pull request adheres to the repository's [Code of Conduct](https://github.c
 - [ ] The company hires remote employees, or positions are available to remote workers and are clearly illustrated as such
 - [ ] A [company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md) is included - __Required__ for new additions. (This can be a basic outline but at least something please)
 - [ ] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
-- [ ] __Region__ details the geographic regions in which this company's employees can reside. For more details see the instructions in the [example company profile](/company-profiles/example.md).
+- [ ] __Region__ details the geographic regions in which this company's employees can reside. For more details see the instructions in the [example company profile](/company-profiles/example.md#region).
 - [ ] __How to apply__ details the best approach for new applications, page on site where open position are listed, and any other help available for job hunters

--- a/company-profiles/example.md
+++ b/company-profiles/example.md
@@ -14,7 +14,28 @@ Explain a bit about your remote culture here.
 
 ## Region
 
-Is your company open to US-based remote employees only? Other countries? Worldwide? Explain here.
+Where are remote employees accepted? List either 1 country (eg **USA**), 1 region (eg **North America**), a list of multiple regions, or **Worldwide**.
+
+See the [UN Statistical Division's country codes](https://unstats.un.org/unsd/methodology/m49/) for a list of accepted countries.
+
+The list of accepted regions is based on the UN Statistical Division's region codes, on the same page:
+
+* Africa
+* Asia
+* Caribbean
+* Europe
+* Latin America
+* North America
+* Oceania (*this includes Australia*)
+
+### Example region 1
+USA
+
+### Example region 2
+North America, Latin America, Caribbean
+
+### Example region 3
+Worldwide
 
 ## Company technologies
 


### PR DESCRIPTION
Updating the rules on the region section for contributing company information as per #485

This is a modified version of the [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md).

This pull request adheres to the repository's [Code of Conduct](https://github.com/remoteintech/remote-jobs/blob/master/CODE_OF_CONDUCT.md).

- [ ] I am an employee of the company mentioned and confirm all included details are correct
- [ ] This PR contains housekeeping only (URL edits, copy changes etc)
- [ ] You know your alphabet - company is listed in alphabetical order in the README
- [ ] The company directly hires employees. No bootcamps / freelance sites / etc
- [ ] The company hires remote employees, or positions are available to remote workers and are clearly illustrated as such
- [ ] A [company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md) is included - __Required__ for new additions. (This can be a basic outline but at least something please)
- [ ] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
- [ ] __Region__ details any restrictions to applicants based on geography
- [ ] __How to apply__ details the best approach for new applications, page on site where open position are listed, and any other help available for job hunters
