### PR TITLE
Add BetterUp to the list of remote companies

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Name | Website | Region
 [Basecamp](/company-profiles/basecamp.md) | https://basecamp.com/ | Worldwide
 [BeBanjo](/company-profiles/bebanjo.md) ⚠️️ | http://bebanjo.com/ |
 [Betable](/company-profiles/betable.md) ⚠️️ | https://corp.betable.com/ |
+[BetterUp](/company-profiles/betterup.md) | https://betterup.co | USA
 [Big Cartel](/company-profiles/big-cartel.md) | http://www.bigcartel.com | USA
 [Big Wheel Brigade](/company-profiles/big-wheel-brigade.md) | http://www.bigwheelbrigade.com/ | USA
 [Bitnami](/company-profiles/bitnami.md) | http://bitnami.com/ | Worldwide

--- a/company-profiles/betterup.md
+++ b/company-profiles/betterup.md
@@ -1,0 +1,47 @@
+# BetterUp
+
+## Company blurb
+
+[BetterUp](https://www.betterup.co/en-us/about/)'s mission is to enable people to live their lives with more purpose, passion, and clarity with a new breed of personalized coaching that is rooted in evidence-based science and is highly accessible. We have built a team of world class behavioral scientists, health experts, navy seals, and even olympic medalists
+
+We are an agile development shop that lives and breathes lean startup principles, continuous deployment, and have built culture of engineering quality where each team member is empowered to have an impact on our mission of building a platform for transformational behavior change.
+
+## Company size
+
+140 people and growing fast
+
+## Remote status
+
+~50% of the company is remote, and the engineering team is 90%+ remote.
+
+## Region
+
+Western hemisphere primarily at the moment.
+
+## Company technologies
+
+Our principles and practices:
+
+* Comprehensive test coverage (> 95%)
+* Maintaining up to date dependencies (minor dependencies upgraded within 1 week of release, major dependencies 1 month)
+* Continuous Deployment (ship early, ship often)
+* Performance as a feature (< 250ms 95th percentile API response time)
+* "Just in time" Architecture (invest in architecture in lockstep with product initiatives)
+
+Our tech stack includes:
+
+* Ruby on Rails
+* EmberJS
+* PostgreSQL
+* Heroku
+* iOS (Swift)
+* Android (Kotlin)
+
+
+## Office locations
+
+Our headquarters is in San Francisco and we have a satellite office in Phoenix, AZ.
+
+## How to apply
+
+We are hiring! Visit [https://betterup.co/jobs/](https://betterup.co/jobs/)

--- a/company-profiles/betterup.md
+++ b/company-profiles/betterup.md
@@ -12,11 +12,11 @@ We are an agile development shop that lives and breathes lean startup principles
 
 ## Remote status
 
-~50% of the company is remote, and the engineering team is 90%+ remote.
+~50% of the company is remote, and the engineering team is 90%+ remote. We have a strong remote culture and constantly refine our practices and processes to ensure remote employees as integral parts of every team they are on. We also participate in quarterly retreats to meet up in person.
 
 ## Region
 
-Western hemisphere primarily at the moment.
+North America, Latin America
 
 ## Company technologies
 


### PR DESCRIPTION
This is a modified version of the [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md).

This pull request adheres to the repository's [Code of Conduct](https://github.com/remoteintech/remote-jobs/blob/master/CODE_OF_CONDUCT.md).

- [X] I am an employee of the company mentioned and confirm all included details are correct
- [ ] This PR contains housekeeping only (URL edits, copy changes etc)
- [X] You know your alphabet - company is listed in alphabetical order in the README
- [X] The company directly hires employees. No bootcamps / freelance sites / etc
- [X] The company hires remote employees, or positions are available to remote workers and are clearly illustrated as such
- [X] A [company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md) is included - __Required__ for new additions. (This can be a basic outline but at least something please)
- [X] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
- [X] __Region__ details the geographic regions in which this company's employees can reside. For more details see the instructions in the [example company profile](/company-profiles/example.md#region).
- [X] __How to apply__ details the best approach for new applications, page on site where open position are listed, and any other help available for job hunters
