### PR TITLE
Improve error message for filename/title mismatch

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -302,9 +302,9 @@ exports.parseFromDirectory = contentPath => {
 			filenameExpected.substring( 0, filenameBase.length + 1 ) !== filenameBase + '-'
 		) {
 			profileError(
-				'Expected filename "%s.md" for company "%s"',
-				filenameExpected,
-				companyName
+				'Company title "%s" doesn\'t match filename (expected ~ "%s.md")',
+				companyName,
+				filenameExpected
 			);
 		}
 

--- a/test/validation-errors.js
+++ b/test/validation-errors.js
@@ -68,10 +68,10 @@ describe( 'validation errors', () => {
 				'10up.md: Expected 1 first-level heading but found 0',
 				'10up.md: The main title is wrapped inside of another element.',
 				'10up.md: Company name looks wrong: ""',
-				'17hats.md: Expected filename "a-company-called-17hats.md" for company "A company called 17hats"',
+				'17hats.md: Company title "A company called 17hats" doesn\'t match filename (expected ~ "a-company-called-17hats.md")',
 				'18f.md: Company name looks wrong: "$%$#%$"',
 				'and-yet.md: Expected 1 first-level heading but found 2',
-				'let-s-encrypt.md: Expected filename "lets-encrypt.md" for company "Let\'s Encrypt"',
+				'let-s-encrypt.md: Company title "Let\'s Encrypt" doesn\'t match filename (expected ~ "lets-encrypt.md")',
 			],
 		} );
 	} );


### PR DESCRIPTION
Improves the error message from https://github.com/remoteintech/remote-jobs/pull/519#issuecomment-451965196:

```diff
-etch.md: Expected filename "basecamp.md" for company "Basecamp"
+etch.md: Company title "Basecamp" doesn't match filename (expected ~ "basecamp.md")
```