### PR TITLE
Add company profile for Giant Swarm

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Name | Website | Region
 [Geckoboard](/company-profiles/geckoboard.md) | https://www.geckoboard.com | UK
 [General Assembly](/company-profiles/general-assembly.md) ⚠️️ | https://generalassemb.ly/ |
 [Ghost Foundation](/company-profiles/the-ghost-foundation.md) | https://ghost.org/ | Worldwide
-[Giant Swarm](/company-profiles/giant-swarm.md) ⚠️️ | https://giantswarm.io | Worldwide
+[Giant Swarm](/company-profiles/giant-swarm.md) | https://giantswarm.io | Europe / US (East Coast)
 [GigSalad](/company-profiles/gigsalad.md) | https://www.gigsalad.com/ | US
 [Gitbook](/company-profiles/gitbook.md) ⚠️️ | https://www.gitbook.com/ |
 [GitHub](/company-profiles/github.md) | https://github.com/ | Worldwide

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Name | Website | Region
 [Geckoboard](/company-profiles/geckoboard.md) | https://www.geckoboard.com | UK
 [General Assembly](/company-profiles/general-assembly.md) ⚠️️ | https://generalassemb.ly/ |
 [Ghost Foundation](/company-profiles/the-ghost-foundation.md) | https://ghost.org/ | Worldwide
-[Giant Swarm](/company-profiles/giant-swarm.md) | https://giantswarm.io | Europe / US (East Coast)
+[Giant Swarm](/company-profiles/giant-swarm.md) | https://giantswarm.io | Europe
 [GigSalad](/company-profiles/gigsalad.md) | https://www.gigsalad.com/ | US
 [Gitbook](/company-profiles/gitbook.md) ⚠️️ | https://www.gitbook.com/ |
 [GitHub](/company-profiles/github.md) | https://github.com/ | Worldwide

--- a/company-profiles/giant-swarm.md
+++ b/company-profiles/giant-swarm.md
@@ -2,7 +2,7 @@
 
 ## Company blurb
 
-Giant Swarm is a leader in cloud-native infrastructures and provides managed
+Giant Swarm is a leader in cloud-native infrastructure and provides managed
 Kubernetes clusters to run containerized applications both on-premises and in
 the cloud. Automation is essential for us and our stack consists of
 microservices and Kubernetes Operators (custom controllers).

--- a/company-profiles/giant-swarm.md
+++ b/company-profiles/giant-swarm.md
@@ -17,7 +17,7 @@ and all our processes are designed for remote working.
 
 ## Region
 
-Europe, USA (East Coast)
+Europe
 
 ## Company technologies
 

--- a/company-profiles/giant-swarm.md
+++ b/company-profiles/giant-swarm.md
@@ -2,9 +2,10 @@
 
 ## Company blurb
 
-Giant Swarm provide managed Kubernetes for Enterprises using Kubernetes.
-Automation is essential for us and our stack consists of microservices and
-Kubernetes Operators (custom controllers).
+Giant Swarm is a leader in cloud-native infrastructures and provides managed
+Kubernetes clusters to run containerized applications both on-premises and in
+the cloud. Automation is essential for us and our stack consists of
+microservices and Kubernetes Operators (custom controllers).
 
 ## Company size
 

--- a/company-profiles/giant-swarm.md
+++ b/company-profiles/giant-swarm.md
@@ -2,10 +2,31 @@
 
 ## Company blurb
 
-⚠ We don't have much information about this company yet!
+Giant Swarm provide managed Kubernetes for Enterprises using Kubernetes.
+Automation is essential for us and our stack consists of microservices and
+Kubernetes Operators (custom controllers).
 
-If you know something we don't, help us fill it in!  Here's how:
+## Company size
 
-- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
-- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
-- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/giant-swarm.md)
+20-50
+
+## Remote status
+
+We are remote first. Our HQ is in Cologne, Germany but most staff are remote
+and all our processes are designed for remote working.
+
+## Region
+
+Europe, USA (East Coast)
+
+## Company technologies
+
+AWS, Azure, Go, Docker, Linux, Kubernetes
+
+## Office locations
+
+Cologne, Germany
+
+## How to apply
+
+[Giant Swarm Careers](https://giantswarm.breezy.hr/)


### PR DESCRIPTION
This is a modified version of the [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md).

This pull request adheres to the repository's [Code of Conduct](https://github.com/remoteintech/remote-jobs/blob/master/CODE_OF_CONDUCT.md).

- [x] I am an employee of the company mentioned and confirm all included details are correct
- [ ] This PR contains housekeeping only (URL edits, copy changes etc)
- [x] You know your alphabet - company is listed in alphabetical order in the README
- [x] The company directly hires employees. No bootcamps / freelance sites / etc
- [x] The company hires remote employees, or positions are available to remote workers and are clearly illustrated as such
- [x] A [company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md) is included - __Required__ for new additions. (This can be a basic outline but at least something please)
- [x] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
- [x] __Region__ details the geographic regions in which this company's employees can reside. For more details see the instructions in the [example company profile](/company-profiles/example.md#region).
- [x] __How to apply__ details the best approach for new applications, page on site where open position are listed, and any other help available for job hunters
