### PR TITLE
update broken link url to current hiring page

### DIFF
--- a/company-profiles/oddball.md
+++ b/company-profiles/oddball.md
@@ -30,4 +30,4 @@ We have a small coworking space in sunny Los Angeles, CA, but all of the company
 
 ## How to apply
 
-Visit our [hiring page](https://oddball.io/hiring)
+Visit our [hiring page](https://oddball.io/jobs)


### PR DESCRIPTION
This is a modified version of the [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md).

This pull request adheres to the repository's [Code of Conduct](https://github.com/remoteintech/remote-jobs/blob/master/CODE_OF_CONDUCT.md).

- [ ] I am an employee of the company mentioned and confirm all included details are correct
- [x] This PR contains housekeeping only (URL edits, copy changes etc)
- [ ] You know your alphabet - company is listed in alphabetical order in the README
- [ ] The company directly hires employees. No bootcamps / freelance sites / etc
- [ ] The company hires remote employees, or positions are available to remote workers and are clearly illustrated as such
- [ ] A [company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md) is included - __Required__ for new additions. (This can be a basic outline but at least something please)
- [ ] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
- [ ] __Region__ details the geographic regions in which this company's employees can reside. For more details see the instructions in the [example company profile](/company-profiles/example.md#region).
- [ ] __How to apply__ details the best approach for new applications, page on site where open position are listed, and any other help available for job hunters
