### PR TITLE
add jobs link to TrussWorks company blurb

### DIFF
--- a/company-profiles/trussworks.md
+++ b/company-profiles/trussworks.md
@@ -26,4 +26,4 @@ We have a small office in San Francisco; however, it's effectively a co-working 
 
 ## How to apply
 
-Read our [jobs page] and see if anything there is interesting to you!
+Read our [jobs page](https://truss.works/jobs) and see if anything there is interesting to you!


### PR DESCRIPTION
This is a housekeeping update to add the jobs URL not included in #583. I hid the rest of the checklist, but if you prefer it displayed please feel free to uncomment it. :)

- - -

This is a modified version of the [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md).

This pull request adheres to the repository's [Code of Conduct](https://github.com/remoteintech/remote-jobs/blob/master/CODE_OF_CONDUCT.md).

- [x] I am an employee of the company mentioned and confirm all included details are correct
- [x] This PR contains housekeeping only (URL edits, copy changes etc)
<!--
- [x] You know your alphabet - company is listed in alphabetical order in the README
- [x] The company directly hires employees. No bootcamps / freelance sites / etc
- [x] The company hires remote employees, or positions are available to remote workers and are clearly illustrated as such
- [x] A [company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md) is included - __Required__ for new additions. (This can be a basic outline but at least something please)
- [x] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
- [x] __Region__ details the geographic regions in which this company's employees can reside. For more details see the instructions in the [example company profile](/company-profiles/example.md#region).
- [x] __How to apply__ details the best approach for new applications, page on site where open position are listed, and any other help available for job hunters
-->