### PR TITLE
feat: add Roadtrippers as another company that hires remotely

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ Name | Website | Region
 [RenoFi](/company-profiles/renofi.md) | https://renofi.com/ |
 [Research Square](/company-profiles/research-square.md) | https://www.researchsquare.com/ | USA
 [RightScale](/company-profiles/rightscale.md) ⚠️️ | http://www.rightscale.com/ |
+[Roadtrippers](/company-profiles/roadtrippers.md) | https://www.roadtrippers.com | USA
 [rtCamp](/company-profiles/rtcamp-solutions.md) | https://rtcamp.com | India
 [Safari Books Online](/company-profiles/safari-books-online.md) ⚠️️ | https://www.safaribooksonline.com |
 [Salesforce](/company-profiles/salesforce.md) ⚠️️ | https://www.salesforce.com/ |

--- a/company-profiles/roadtrippers.md
+++ b/company-profiles/roadtrippers.md
@@ -1,0 +1,54 @@
+# Roadtrippers
+
+## Company blurb
+
+Roadtrippers is the world's No. 1 road trip planning tool. Our content covers the coolest offbeat places to visit and is powered by our own database, which contains millions of the world’s most interesting locations. Roadtrippers streamlines discovery, planning, booking and navigation into an engaging and intuitive process. Since launching in 2012, Roadtrippers has helped users plan more than 25 million trips. Every year, more than 18 million people visit our site to get the inspiration and information they need to hit the road. We’re proud to be a part of the Togo Group, creating the leading technology platform for road-based travel and outdoor tourism.
+
+## Company size
+
+30-50
+
+## Remote status
+
+We have team members distributed from US west coast to east coast. Our remote team members are given $100/month stipend to make our offices as comfortable as our HQ.
+
+Remote does not mean that your careers will have an invisible ceiling. Our CEO and president work remotely. 
+
+## Region
+
+USA
+
+## Company technologies
+
+Backend:
+
+- Ruby
+- Rails
+- Sidekiq
+
+Frontend:
+- Javascript
+- React
+
+Infrastructure:
+- Amazon Web Services
+- nginx
+- Ansible
+- Packer
+- Docker
+
+Datastores:
+
+- Postgres
+- Redis
+- Memcached
+
+## Office locations
+
+Cincinnati, Ohio
+
+## How to apply
+
+You can find our open jobs and apply directly here: https://www.roadtrippers.com/careers
+
+Note that our third party job listing software has a requirement of city selection, so our remote-eligible positions may have locations listed such as "Cincinnati, Ohio".


### PR DESCRIPTION
This is a modified version of the [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md).

This pull request adheres to the repository's [Code of Conduct](https://github.com/remoteintech/remote-jobs/blob/master/CODE_OF_CONDUCT.md).

- [x] I am an employee of the company mentioned and confirm all included details are correct
- [ ] This PR contains housekeeping only (URL edits, copy changes etc)
- [x] You know your alphabet - company is listed in alphabetical order in the README
- [x] The company directly hires employees. No bootcamps / freelance sites / etc
- [x] The company hires remote employees, or positions are available to remote workers and are clearly illustrated as such
- [x] A [company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md) is included - __Required__ for new additions. (This can be a basic outline but at least something please)
- [x] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
- [x] __Region__ details the geographic regions in which this company's employees can reside. For more details see the instructions in the [example company profile](/company-profiles/example.md#region).
- [x] __How to apply__ details the best approach for new applications, page on site where open position are listed, and any other help available for job hunters
