### PR TITLE
Fix the site build on Netlify

### DIFF
--- a/bin/build-site.js
+++ b/bin/build-site.js
@@ -134,6 +134,9 @@ async function buildSite() {
 			stylesheet.content = $el.html();
 		} else {
 			stylesheet.url = $el.attr( 'href' );
+			if ( /^\/\//.test( stylesheet.url ) ) {
+				stylesheet.url = 'https:' + stylesheet.url;
+			}
 		}
 		return stylesheet;
 	} ).toArray();


### PR DESCRIPTION
Current PRs are failing to build. The remoteintech.company site pulls the CSS rules from the WP.com site, and this is failing because the WP.com site now includes a stylesheet URL without a protocol:

```
//widgets.wp.com/wpcom-block-editor/common.min.css?ver=20190930180734
```

To fix this, we'll add `https:` to the front of any such links.