### PR TITLE
Add company info for betable

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Name | Website | Region
 [Basecamp](/company-profiles/basecamp.md) | https://basecamp.com/ | Worldwide
 [BeBanjo](/company-profiles/bebanjo.md) ⚠️️ | http://bebanjo.com/ |
 [Best Practical Solutions](/company-profiles/best-practical-solutions.md) | https://bestpractical.com/ | Worldwide
-[Betable](/company-profiles/betable.md) ⚠️️ | https://corp.betable.com/ |
+[Betable](/company-profiles/betable.md) ⚠️️ | https://corp.betable.com/ | USA, Europe
 [BetaPeak](/company-profiles/betapeak.md) | https://betapeak.com/ |
 [BetterUp](/company-profiles/betterup.md) | https://betterup.co | USA
 [BeyondPricing](/company-profiles/beyondpricing.md) | https://beyondpricing.com | Worldwide

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Name | Website | Region
 [Basecamp](/company-profiles/basecamp.md) | https://basecamp.com/ | Worldwide
 [BeBanjo](/company-profiles/bebanjo.md) ⚠️️ | http://bebanjo.com/ |
 [Best Practical Solutions](/company-profiles/best-practical-solutions.md) | https://bestpractical.com/ | Worldwide
-[Betable](/company-profiles/betable.md) ⚠️️ | https://corp.betable.com/ | USA, Europe
+[Betable](/company-profiles/betable.md) | https://corp.betable.com/ | USA, Europe
 [BetaPeak](/company-profiles/betapeak.md) | https://betapeak.com/ |
 [BetterUp](/company-profiles/betterup.md) | https://betterup.co | USA
 [BeyondPricing](/company-profiles/beyondpricing.md) | https://beyondpricing.com | Worldwide

--- a/company-profiles/betable.md
+++ b/company-profiles/betable.md
@@ -1,11 +1,20 @@
 # Betable
 
 ## Company blurb
+BETABLE PROVIDES THE ONLY FULL-STACK PLATFORM FOR FRICTIONLESS MARKET ENTRY AND THE CREATION, DISTRIBUTION AND CONSUMPTION OF GAMBLING ENTERTAINMENT.
 
-⚠ We don't have much information about this company yet!
+Betable’s platform will become the rails for creating, distributing and consuming all real-money gambling games.
 
-If you know something we don't, help us fill it in!  Here's how:
+## Remote status
+We have team-members in Edmonton, Manchester and San Francisco.
 
-- Read our [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md)
-- Have a look at our [example company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md)
-- Follow the structure of the example profile and [send us a pull request with your changes to this file!](https://github.com/remoteintech/remote-jobs/edit/master/company-profiles/betable.md)
+## Region
+USA, Europe
+
+## Office locations
+* Edmonton, Canada
+* San Francisco, California
+* Manchester, England
+
+## How to apply
+Vist [Betable Careers page](https://corp.betable.com/careers) for information on how to apply.


### PR DESCRIPTION
This is a modified version of the [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md).

This pull request adheres to the repository's [Code of Conduct](https://github.com/remoteintech/remote-jobs/blob/master/CODE_OF_CONDUCT.md).

- [ ] I am an employee of the company mentioned and confirm all included details are correct
- [x] This PR contains housekeeping only (URL edits, copy changes etc)
- [x] You know your alphabet - company is listed in alphabetical order in the README
- [x] The company directly hires employees. No bootcamps / freelance sites / etc
- [x] The company hires remote employees, or positions are available to remote workers and are clearly illustrated as such
- [x] A [company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md) is included - __Required__ for new additions. (This can be a basic outline but at least something please)
- [x] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
- [x] __Region__ details the geographic regions in which this company's employees can reside. For more details see the instructions in the [example company profile](/company-profiles/example.md#region).
- [x] __How to apply__ details the best approach for new applications, page on site where open position are listed, and any other help available for job hunters
