### PR TITLE
Make footer social links always white

### DIFF
--- a/site/assets/site.css
+++ b/site/assets/site.css
@@ -27,6 +27,10 @@ a:hover,
 	color: #999;
 }
 
+.jetpack-social-navigation a {
+	color: #fff;
+}
+
 /**
  * Styles for company profile pages
  */


### PR DESCRIPTION
Before this PR, the links to GitHub and Twitter can look a bit weird if only one of them has been visited, since the one that has been visited will show up in red instead of white.

After this PR they will always show up in white.