### PR TITLE
Add Formidable to Remote Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Name | Website | Region
 [Fire Engine Red](/company-profiles/fire-engine-red.md) ⚠️️ | http://fire-engine-red.com/ |
 [Focusnetworks](/company-profiles/focusnetworks.md) ⚠️️ | http://focusnetworks.com.br | Brazil
 [Fog Creek](/company-profiles/fog-creek-software.md) | https://www.fogcreek.com/ | Worldwide
+[Formidable](/company-profiles/formidable.md) | https://www.formidable.com/ | US, Canada, UK, Europe
 [Formstack](/company-profiles/formstack.md) | https://www.formstack.com/ | Worldwide
 [Four Kitchens](/company-profiles/four-kitchens.md) | https://fourkitchens.com/ |
 [fournova](/company-profiles/fournova.md) ⚠️️ | https://www.fournova.com/ |

--- a/company-profiles/formidable.md
+++ b/company-profiles/formidable.md
@@ -1,0 +1,51 @@
+# Formidable
+
+## Company blurb
+
+Formidable is a Seattle, Denver, Phoenix, and London-based engineering consultancy and open source software organization, specializing in React.js, React Native, GraphQL, Node.js, and the extended JavaScript ecosystem.
+
+We practice "consulting through delivery", and our teams of engineers embed remotely with client engineers, product managers, and designers. We have a heavy focus on code review and testing. Our clients reach out to us because we have developed hard-earned expertise in our areas of focus, and our engineers are trusted with the architecture of very large-scale systems. We plug into whatever agile methodology our clients use, though after observing the workflow for a while, we provide suggestions for improvements via retrospectives.
+
+Everyone at Formidable help to foster a culture of supportive learning and knowledge exchange, both within our company and throughout the greater JavaScript community. We work hard to live our core values of Inclusion, Autonomy, and Mastery:
+
+- We have an internally open pay system tied to a detailed career ladder to promote transparency around pay and engineering levels, and keep the company accountable for equal pay for equal work.
+- We trust our employees to do the jobs we hired them to do. Each team is responsible for making their own decisions and coming up with the appropriate solutions for their particular project.
+- We provide a bottomless continuing education stipend and internal trainings to help our employees skill up.
+
+## Company size
+
+75+
+
+## Remote status
+
+We have an entire remote team throughout the US and building a remote Toronto-based Canada team. We collaborate via Slack, Github (or the DVCS of our clients' choice), and video calls.
+
+We consider Remote to be a first-class location, and we have remote engineering managers. We provide a travel stipend to encourage visits to our physical offices, but it's not required. We have an annual "Formidagathering" where everyone gets together for a week in Seattle to learn, play, socialize, and work together.
+
+Though we hire entry-level engineers in our physical locations, we recognize that folks early in their career need more hands-on mentorship, something that's harder to provide to remote employees. That's why we require that our remote engineers have 2-3 years of professional experience.
+
+## Region
+
+United States, United Kingdom, Canada, Europe
+
+## Company technologies
+
+- React
+- React Native
+- Node
+- GraphQL
+- Kubernetes
+- AWS
+
+## Office locations
+
+- Seattle, WA
+- London, UK
+- Phoenix, AZ
+- Denver, CO
+- Remote, North America
+- Remote, Europe
+
+## How to apply
+
+[Apply here](https://formidable.com/careers/)


### PR DESCRIPTION
This is a modified version of the [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md).

This pull request adheres to the repository's [Code of Conduct](https://github.com/remoteintech/remote-jobs/blob/master/CODE_OF_CONDUCT.md).

- [x] I am an employee of the company mentioned and confirm all included details are correct
- [ ] This PR contains housekeeping only (URL edits, copy changes etc)
- [x] You know your alphabet - company is listed in alphabetical order in the README
- [x] The company directly hires employees. No bootcamps / freelance sites / etc
- [x] The company hires remote employees, or positions are available to remote workers and are clearly illustrated as such
- [x] A [company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md) is included - __Required__ for new additions. (This can be a basic outline but at least something please)
- [x] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
- [x] __Region__ details the geographic regions in which this company's employees can reside. For more details see the instructions in the [example company profile](/company-profiles/example.md#region).
- [x] __How to apply__ details the best approach for new applications, page on site where open position are listed, and any other help available for job hunters
