### PR TITLE
TrussWorks: Update company size and technologies

### DIFF
--- a/company-profiles/trussworks.md
+++ b/company-profiles/trussworks.md
@@ -6,7 +6,7 @@ Truss works side by side with our clients to design, build, and scale modern sof
 
 ## Company size
 
-About 70 folks as of June 2019.
+About 100 folks as of May 2020.
 
 ## Remote status
 
@@ -18,7 +18,7 @@ USA only; many of our contracts with the US government and with US healthcare pr
 
 ## Company technologies
 
-Lots, to be honest. Our clients tend to use tools like Python, Ruby, JavaScript, and Java (for data processing pipelines). We tend to use tools like Go, Python, modern JavaScript, AWS, terraform. Our projects are often web applications deployed into cloud environments, and not always; we've done data processing pipelines, native mobile applications, and various kinds of workshop training (design and engineering) as well.
+Lots, to be honest. Our clients tend to use languages like Python, Ruby, and JavaScript. We tend to use languages like Go, Python, and modern JavaScript and build infrastructure in AWS with Terraform. Our projects are often web applications deployed into cloud environments, and not always; we've done data processing pipelines, native mobile applications, and various kinds of workshop training (design and engineering) as well.
 
 ## Office locations
 


### PR DESCRIPTION
This is a modified version of the [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md).

This pull request adheres to the repository's [Code of Conduct](https://github.com/remoteintech/remote-jobs/blob/master/CODE_OF_CONDUCT.md).

- [x] I am an employee of the company mentioned and confirm all included details are correct
- [x] This PR contains housekeeping only (URL edits, copy changes etc)
- [x] You know your alphabet - company is listed in alphabetical order in the README
- [x] The company directly hires employees. No bootcamps / freelance sites / etc
- [x] The company hires remote employees, or positions are available to remote workers and are clearly illustrated as such
- [x] A [company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md) is included - __Required__ for new additions. (This can be a basic outline but at least something please)
- [x] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
- [x] __Region__ details the geographic regions in which this company's employees can reside. For more details see the instructions in the [example company profile](/company-profiles/example.md#region).
- [x] __How to apply__ details the best approach for new applications, page on site where open position are listed, and any other help available for job hunters
