### PR TITLE
Adding new company profile of Adaface

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Name | Website | Region
 [abiturma](/company-profiles/abiturma.md) | https://www.abiturma.de/ | Germany
 [Ably](/company-profiles/ably.md) | https://www.ably.io/ | Europe
 [Acquia](/company-profiles/acquia.md) | https://www.acquia.com/ | Worldwide
+[Adaface](/company-profiles/adaface.md) | https://www.adaface.com | Asia
 [Ad Hoc](/company-profiles/ad-hoc.md) | https://www.adhocteam.us/ | USA
 [Adzuna](/company-profiles/adzuna.md) | https://www.adzuna.co.uk/ | Worldwide
 [AE Studio](/company-profiles/aestudio.md) | https://ae.studio/ | USA, BR

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Name | Website | Region
 [abiturma](/company-profiles/abiturma.md) | https://www.abiturma.de/ | Germany
 [Ably](/company-profiles/ably.md) | https://www.ably.io/ | Europe
 [Acquia](/company-profiles/acquia.md) | https://www.acquia.com/ | Worldwide
-[Adaface](/company-profiles/adaface.md) | https://www.adaface.com | Asia
 [Ad Hoc](/company-profiles/ad-hoc.md) | https://www.adhocteam.us/ | USA
+[Adaface](/company-profiles/adaface.md) | https://www.adaface.com | Asia
 [Adzuna](/company-profiles/adzuna.md) | https://www.adzuna.co.uk/ | Worldwide
 [AE Studio](/company-profiles/aestudio.md) | https://ae.studio/ | USA, BR
 [Aerolab](/company-profiles/aerolab.md) | https://aerolab.co/ | Latin America

--- a/company-profiles/adaface.md
+++ b/company-profiles/adaface.md
@@ -1,0 +1,30 @@
+# Adaface
+
+## Company blurb
+
+Adaface helps companies identify top engineers by automating the hiring process. We automate screening with Ada, a conversational AI for first round tech interviews. For second round interviews, we provide [remote pair programming tool](https://www.adaface.com/pair-pro) with video conference, code compiler and shared editor.
+
+## Company size
+
+0-20
+
+## Remote status
+
+Completeley remote from 2019.
+
+## Region
+
+Asia
+
+## Company technologies
+
+ReactJs, Socket.IO, Firebase, MySQL, Docker, Django, MongoDb
+
+## Office locations
+
+- 32 Carpenter Street, Singapore
+- Innov8 Coworking, Koramangala, Bangalore, India
+
+## How to apply
+
+https://angel.co/company/adaface


### PR DESCRIPTION
All details from sample company profile are added

This is a modified version of the [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md).

This pull request adheres to the repository's [Code of Conduct](https://github.com/remoteintech/remote-jobs/blob/master/CODE_OF_CONDUCT.md).

- [x] I am an employee of the company mentioned and confirm all included details are correct
- [x] This PR contains housekeeping only (URL edits, copy changes etc)
- [x] You know your alphabet - company is listed in alphabetical order in the README
- [x] The company directly hires employees. No bootcamps / freelance sites / etc
- [x] The company hires remote employees, or positions are available to remote workers and are clearly illustrated as such
- [x] A [company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md) is included - __Required__ for new additions. (This can be a basic outline but at least something please)
- [x] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
- [x] __Region__ details the geographic regions in which this company's employees can reside. For more details see the instructions in the [example company profile](/company-profiles/example.md#region).
- [x] __How to apply__ details the best approach for new applications, page on site where open position are listed, and any other help available for job hunters
