### PR TITLE
Change 1Password region

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Name | Website | Region
 [15Five](/company-profiles/15five.md) | https://www.15five.com | Europe, Americas
 [17hats](/company-profiles/17hats.md) | https://www.17hats.com/ | Worldwide
 [18F](/company-profiles/18f.md) | https://18f.gsa.gov/ | USA
-[1Password](/company-profiles/1password.md) | https://www.1password.com | Worldwide
+[1Password](/company-profiles/1password.md) | https://www.1password.com | USA, Canada
 [abiturma](/company-profiles/abiturma.md) | https://www.abiturma.de/ | Germany
 [Ably](/company-profiles/ably.md) | https://www.ably.io/ | Europe
 [Acquia](/company-profiles/acquia.md) | https://www.acquia.com/ | Worldwide


### PR DESCRIPTION
I checked their jobs (which is [here](https://jobs.lever.co/1password)). They have positions only for USA and Canada.

This pull request adheres to the repository's [Code of Conduct](https://github.com/remoteintech/remote-jobs/blob/master/CODE_OF_CONDUCT.md).

- [x] __Region__ details the geographic regions in which this company's employees can reside. For more details see the instructions in the [1Password](https://jobs.lever.co/1password).
