### PR TITLE
Add remote work entry for Seaplane

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ Name | Website | Region
 [Scopic Software](/company-profiles/scopic-software.md) | http://scopicsoftware.com/ | Worldwide
 [ScrapingBee](/company-profiles/scrapingbee.md) | https://www.scrapingbee.com/ | Worldwide
 [Scrapinghub](/company-profiles/scrapinghub.md) ⚠️️ | http://scrapinghub.com/ |
+[Seaplane](/company-profiles/seaplane.md) | https://www.seaplane.io/ | Worldwide
 [SecurityScorecard](/company-profiles/securityscorecard.md) ⚠️️ | https://securityscorecard.com/ |
 [SEED](/company-profiles/seed.md) ⚠️️ | https://seed.co/ |
 [Semaphore](/company-profiles/semaphore.md) | https://semaphoreci.com | Europe

--- a/company-profiles/seaplane.md
+++ b/company-profiles/seaplane.md
@@ -1,0 +1,29 @@
+# Seaplane
+
+## Company blurb
+
+Seaplane is the serverless cloud for modern enterprises. Our customers deploy their Functions Everywhere™ and our service seamlessly moves them across Edge, On-Prem, and multi-Cloud deployments to provide the best performance for their end users. We are backed by Sequoia Capital and - while started in Silicon Valley - are a 100% remote company, committed to growing an inclusive team with the most talented people no matter where you live.
+
+## Company size
+
+<5 (as of June 2020)
+
+## Remote status
+
+All of us are remote. No offices. Currently we’re all based in California, but looking anywhere/everywhere for new hires.
+
+## Region
+
+Worldwide.
+
+## Company technologies
+
+Rust, Linux, AWS Firecracker, GRPC, and many others depending on the team.
+
+## Office locations
+
+None. Founding team currently remote across California.
+
+## How to apply
+
+Visit our careers site for open positions and to apply: https://careers.smartrecruiters.com/SeaplaneIOInc


### PR DESCRIPTION
This is a modified version of the [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md).

This pull request adheres to the repository's [Code of Conduct](https://github.com/remoteintech/remote-jobs/blob/master/CODE_OF_CONDUCT.md).

- [x] I am an employee of the company mentioned and confirm all included details are correct
- [x] This PR contains housekeeping only (URL edits, copy changes etc)
- [x] You know your alphabet - company is listed in alphabetical order in the README
- [x] The company directly hires employees. No bootcamps / freelance sites / etc
- [x] The company hires remote employees, or positions are available to remote workers and are clearly illustrated as such
- [x] A [company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md) is included - __Required__ for new additions. (This can be a basic outline but at least something please)
- [x] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
- [x] __Region__ details the geographic regions in which this company's employees can reside. For more details see the instructions in the [example company profile](/company-profiles/example.md#region).
- [x] __How to apply__ details the best approach for new applications, page on site where open position are listed, and any other help available for job hunters
