### PR TITLE
added Amazon with links to remote opportunities landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Name | Website | Region
 [Alley](/company-profiles/alley.md) | http://alley.co | USA, Canada, Western Europe
 [allyDVM](/company-profiles/allydvm.md) | http://www.allydvm.com/ | USA
 [AlphaSights](/company-profiles/alphasights.md) | https://engineering.alphasights.com | USA, UK, (EST, GMT)
+[Amazon](/company-profiles/amazon.md) | https://www.amazon.jobs/en/locations/virtual-locations | Worldwide
 [Anexus](/company-profiles/anexus.md) | http://www.anexusit.com/ | Latin America
 [Anomali](/company-profiles/anomali.md) | https://www.anomali.com/company/careers | USA, UK, Singapore
 [apartment therapy](/company-profiles/apartment-therapy.md) | http://www.apartmenttherapy.com/ | USA

--- a/company-profiles/amazon.md
+++ b/company-profiles/amazon.md
@@ -1,0 +1,30 @@
+# Amazon
+
+## Company blurb
+
+When Amazon.com launched in 1995, it was with the mission “to be Earth’s most customer-centric company, where customers can find and discover anything they might want to buy online, and endeavors to offer its customers the lowest possible prices.” This goal continues today, but Amazon’s customers are worldwide now, and have grown to include millions of Consumers, Sellers, Content Creators, and Developers & Enterprises. Each of these groups has different needs, and we always work to meet those needs, innovating new solutions to make things easier, faster, better, and more cost-effective. [Learn about working at Amazon](https://www.amazon.jobs/en/working/working-amazon)
+
+## Company size
+
+500+
+
+## Remote status
+
+Some [remote opportunities](https://www.amazon.jobs/en/locations/virtual-locations)
+
+## Region
+
+Worldwide [locations](https://www.amazon.jobs/en/locations/virtual-locations)
+
+## Company technologies
+
+We do not require that you know any specific programming language before interviewing for a tech position. However, familiarity with a prominent language is generally a prerequisite for success. You should be familiar with the syntax of languages such as Java, Python, C#, C/C++, or Ruby. You should also know some of the languages’ nuances, such as how memory management works, or the most commonly used collections, libraries, etc. [More info](https://www.amazon.jobs/en/landing_pages/software-development-topics)
+
+## Office locations
+
+[Worldwide locations](https://www.amazon.jobs/en/locations/?&continent=all&cache)
+
+## How to apply
+
+Find jobs: [careers website](https://www.amazon.jobs/)
+Remote opportunities: [virtual locations](https://www.amazon.jobs/en/locations/virtual-locations)


### PR DESCRIPTION
This is a modified version of the [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/master/CONTRIBUTING.md).

This pull request adheres to the repository's [Code of Conduct](https://github.com/remoteintech/remote-jobs/blob/master/CODE_OF_CONDUCT.md).

- [x] I am an employee of the company mentioned and confirm all included details are correct
- [ ] This PR contains housekeeping only (URL edits, copy changes etc)
- [x] You know your alphabet - company is listed in alphabetical order in the README
- [x] The company directly hires employees. No bootcamps / freelance sites / etc
- [x] The company hires remote employees, or positions are available to remote workers and are clearly illustrated as such
- [x] A [company profile](https://github.com/remoteintech/remote-jobs/blob/master/company-profiles/example.md) is included - __Required__ for new additions. (This can be a basic outline but at least something please)
- [x] __Remote status__ has details regarding how the culture includes remote employees, how the company integrated remote workers, etc
- [x] __Region__ details the geographic regions in which this company's employees can reside. For more details see the instructions in the [example company profile](/company-profiles/example.md#region).
- [x] __How to apply__ details the best approach for new applications, page on site where open position are listed, and any other help available for job hunters
