### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -59,8 +59,8 @@ function toIdentifierCase( text ) {
 				return word.toLowerCase();
 			}
 			return (
-				word.substr( 0, 1 ).toUpperCase()
-				+ word.substr( 1 ).toLowerCase()
+				word.slice( 0, 1 ).toUpperCase()
+				+ word.slice( 1 ).toLowerCase()
 			);
 		} )
 		.join( '' );


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.