### PR TITLE
Add Cards Against Humanity Careers page link

### DIFF
--- a/company-profiles/cards-against-humanity.md
+++ b/company-profiles/cards-against-humanity.md
@@ -28,4 +28,4 @@ Chicago, Illinois
 
 ## How to apply
 
-Job openings will likely be advertised on their [blog](https://cah.tumblr.com/). You can also email them at Mail@CardsAgainstHumanity.com.
+Job openings are [posted on the Careers page](https://www.cardsagainsthumanity.com/careers) and [will likely be advertised on their blog](https://cah.tumblr.com/). You can also email them at Mail@CardsAgainstHumanity.com.


### PR DESCRIPTION
This is a modified version of, and should adhere to, the [Contributing Guidelines](../../main/.github/CONTRIBUTING.md).

Add's a link to the Cards Against Humanity Careers page and expands the blog URL linked text for accessibility.

<!--
Hello, thank you for your contribution, please read through this whole file before submitting your Pull Request.

Title your pull request descriptively:

* edit X company
* add new company - COMPANY
* Copy tweaks

Please read and check the boxes in the list below that apply!

If updating or adding a company, please include details about what you are changing. 

If you are adding a new entry to the list, your contributio (Pull Request) should include a company profile AND line entry to the readme file.

Check off this list as appropriate (add an x between the []). It will be used by @dougaitken when reviewing your contribution, like this: [x]

DO NOT DELETE ANYTHING IN THIS COMMENT.
-->

* [X] This PR contains housekeeping only (URL edits, copy changes etc) - **if this is checked, delete other lines that don't apply**
* [X] __How to apply__ details the best approach for new applications, page on site where open position are listed, and any other help available for job hunters
