### PR TITLE
Fix: Update broken careers link for Zemoso

### DIFF
--- a/company-profiles/zemoso.md
+++ b/company-profiles/zemoso.md
@@ -42,4 +42,4 @@ US, Canada and India
 
 ## How to apply
 
-Visit our [website](https://www.zemosolabs.com/open-positions) for current job openings.
+Visit our [website](https://www.zemosolabs.com/careers) for current job openings.


### PR DESCRIPTION
The previous link for job openings was leading to a broken "page not found" page. This commit updates it to the correct careers URL.

## Contributing Guidelines Checklist

This is a modified version of, and should adhere to, the [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/main/.github/CONTRIBUTING.md).

### General Requirements
- [x] This PR contains housekeeping only (URL edits, copy changes etc) - if this is checked, delete other lines that don't apply
- [ ] You are an employee of the company mentioned and confirm all included details are correct
- [x] This pull request adheres to the repository's Code of Conduct

**Note:** Our automated validation system will check your submission and provide feedback. Please address any issues found before requesting review.