### PR TITLE
Add MaintainNow company profile

### DIFF
--- a/src/companies/maintainnow.md
+++ b/src/companies/maintainnow.md
@@ -1,0 +1,40 @@
+---
+title: "MaintainNow"
+slug: maintainnow
+website: https://www.maintainnow.app
+region: americas
+remote_policy: fully-remote
+company_size: startup
+technologies:
+  - react
+  - react-native
+  - aws
+---
+
+## Company blurb
+
+MaintainNow is a fully remote-friendly tech company offering an intuitive, enterprise-grade CMMS platform built for facility maintenance and management across schools and campuses, recreation and sports venues, manufacturing plants, multi-building portfolios, healthcare facilities, and transportation fleets.
+
+## Company size
+
+Less than 10
+
+## Remote status
+
+Fully remote company.
+
+## Region
+
+United States
+
+## Company technologies
+
+React, React Native, AWS
+
+## Office locations
+
+USA (fully remote)
+
+## How to apply
+
+- [Website](https://www.maintainnow.app)


### PR DESCRIPTION
## Summary
- Add MaintainNow - enterprise-grade CMMS platform for facility maintenance
- Fully remote company based in USA

Closes #2046

Co-Authored-By: maintainnow <193628498+maintainnow@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.ai/code)