### PR TITLE
Fix security vulnerabilities in extractDescription filter

### DIFF
--- a/src/_config/filters/extractDescription.js
+++ b/src/_config/filters/extractDescription.js
@@ -25,15 +25,16 @@ export function extractDescription(content, maxLength = 160) {
     }
   }
 
-  // Remove HTML tags and entities
+  // Remove HTML tags using single-character replacement (CodeQL-recommended)
+  // This prevents incomplete sanitization from nested tags like <scr<script>ipt>
   text = text
-    .replace(/<[^>]+>/g, '')                    // Remove HTML tags
-    .replace(/&amp;/g, '&')                     // Decode &amp;
-    .replace(/&lt;/g, '<')                      // Decode &lt;
-    .replace(/&gt;/g, '>')                      // Decode &gt;
+    .replace(/<|>/g, '')                        // Remove < and > characters
+    .replace(/&nbsp;/g, ' ')                    // Decode &nbsp; first (no risk)
     .replace(/&quot;/g, '"')                    // Decode &quot;
     .replace(/&#39;/g, "'")                     // Decode &#39;
-    .replace(/&nbsp;/g, ' ')                    // Decode &nbsp;
+    .replace(/&lt;/g, '')                       // Remove decoded < (was &lt;)
+    .replace(/&gt;/g, '')                       // Remove decoded > (was &gt;)
+    .replace(/&amp;/g, '&')                     // Decode &amp; last to avoid double-decode
     .replace(/\s+/g, ' ')                       // Multiple spaces to single
     .trim();
 


### PR DESCRIPTION
## Summary

Fixes the two security alerts from PR #2089:

- **Alert #7**: Double escaping/unescaping - fixed by decoding `&amp;` last
- **Alert #8**: Incomplete multi-character sanitization - fixed by using single-character `<|>` replacement (CodeQL-recommended approach)

## Changes

- Use `/<|>/g` to strip angle brackets individually instead of matching full tags
- Remove `&lt;` and `&gt;` entirely instead of decoding to `<` and `>`
- Decode `&amp;` last to prevent double-unescaping of `&amp;amp;`

## Test plan

- [x] `npm run build` completes successfully
- [x] Meta descriptions still generate correctly

🤖 Generated with [Claude Code](https://claude.ai/code)