### PR TITLE
Actually use shuffle filter

### DIFF
--- a/src/_config/collections.js
+++ b/src/_config/collections.js
@@ -3,6 +3,7 @@ import {
   regionLabels,
   techLabels
 } from '../_data/companyHelpers.js';
+import { shuffleArray } from './filters/sort-random.js';
 
 /** All blog posts as a collection. */
 export const getAllPosts = collection => {
@@ -18,13 +19,13 @@ export const getAllCompanies = collection => {
   });
 };
 
-/** Featured companies - manually curated list */
+/** Featured companies - randomly selected from curated list */
 export const getFeaturedCompanies = collection => {
   const companies = collection.getFilteredByGlob('./src/companies/**/*.md');
-  return featuredCompanySlugs
+  const matched = featuredCompanySlugs
     .map(slug => companies.find(c => c.data.slug === slug || c.fileSlug === slug))
-    .filter(Boolean)
-    .slice(0, 8);
+    .filter(Boolean);
+  return shuffleArray(matched).slice(0, 8);
 };
 
 /** Recently added companies (by addedAt date from git data or frontmatter) */

--- a/src/_config/filters/sort-random.js
+++ b/src/_config/filters/sort-random.js
@@ -1,3 +1,8 @@
 export const shuffleArray = array => {
-  return array.sort(() => Math.random() - 0.5);
+  const shuffled = [...array];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled;
 };


### PR DESCRIPTION
## Description

Two problems - 
1. It's never used
2. It's not working, 12 companies in the Featured list but the sort wouldn't shown them all

The shuffleArray function in `src/_config/filters/sort-random.js` is registered as the shuffle filter, but grep across all .njk templates returns zero uses.

File: src/_config/filters/sort-random.js:1-3

```export const shuffleArray = array => {
  return array.sort(() => Math.random() - 0.5);
};
```

This is a well-known anti-pattern. `sort()` with a random comparator does not produce a uniform distribution, items near their original positions are statistically favoured. Changed to use [Fisher-Yates](https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#JavaScript_implementation) instead.

## Type of Change

- [ ] New company addition
- [ ] Company information update
- [x] Bug fix
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

### General Requirements
- [x] I have read the [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/main/.github/CONTRIBUTING.md)
- [x] This pull request adheres to the repository's Code of Conduct
- [x] I have tested the build locally with `npm run build:11ty`