### PR TITLE
feat: integrate Carbon Ads for ethical advertising

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,15 @@ Fathom Analytics (privacy-focused) - only loads in production builds.
 - Site ID configured in `src/_data/meta.js`
 - 404 errors tracked via custom event with the attempted URL path
 
+## Advertising
+
+Carbon Ads (ethical, developer-focused) - only loads in production builds.
+- Config: `src/_data/meta.js` (`carbonAds` export)
+- Partial: `src/_includes/partials/carbon-ad.njk`
+- CSS: `src/assets/css/global/blocks/carbon-ad.css`
+- Layout: `base.njk` wraps `<main>` + ad `<aside>` in sidebar composition (production only)
+- Cover format with automatic classic fallback
+
 ## SEO
 
 ### AI Bot Policy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,7 @@ When bumping the version:
 1. Update `version` in `package.json`
 2. Add a new entry at the top of `src/_data/changelog.json`
 
-Changelog entries should be summaries. Call out each company addition by name, but summarise edits, deletions, and fixes. Change types: `added`, `changed`, `fixed`, `removed`.
+Changelog entries should be summaries. Call out each company addition by name with the `Company:` prefix (e.g. `Company: BigData Boutique`), but summarise edits, deletions, and fixes. Change types: `added`, `changed`, `fixed`, `removed`. Descriptions support HTML links — use them to link to company profiles, blog posts, and relevant pages (e.g. `Company: <a href="/companies/bigdata-boutique/">BigData Boutique</a>`).
 
 ## Contributing a Company
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-in-tech",
-  "version": "4.4.1",
+  "version": "4.5.0",
   "description": "A list of semi to fully remote-friendly companies in or around tech",
   "author": "Doug Aitken",
   "license": "ISC",

--- a/src/_data/changelog.json
+++ b/src/_data/changelog.json
@@ -1,5 +1,32 @@
 [
   {
+    "version": "4.5.0",
+    "date": "2026-03-29",
+    "summary": "Carbon Ads integration, new company, dependency updates",
+    "changes": [
+      {
+        "type": "added",
+        "description": "Carbon Ads ethical advertising in a sidebar layout (production only)"
+      },
+      {
+        "type": "added",
+        "description": "BigData Boutique"
+      },
+      {
+        "type": "fixed",
+        "description": "Sticky ad no longer overlays content on mobile viewports"
+      },
+      {
+        "type": "changed",
+        "description": "Updated privacy policy with Carbon Ads disclosure"
+      },
+      {
+        "type": "changed",
+        "description": "Bumped dependencies: autoprefixer, flatted, liquidjs, minimatch, picomatch, rimraf, svgo, yaml"
+      }
+    ]
+  },
+  {
     "version": "4.4.1",
     "date": "2026-02-22",
     "summary": "Date field documentation",

--- a/src/_data/changelog.json
+++ b/src/_data/changelog.json
@@ -10,7 +10,7 @@
       },
       {
         "type": "added",
-        "description": "BigData Boutique"
+        "description": "Company: <a href=\"/companies/bigdata-boutique/\">BigData Boutique</a>"
       },
       {
         "type": "fixed",
@@ -18,7 +18,7 @@
       },
       {
         "type": "changed",
-        "description": "Updated privacy policy with Carbon Ads disclosure"
+        "description": "Updated <a href=\"/privacy/\">privacy policy</a> with Carbon Ads disclosure"
       },
       {
         "type": "changed",

--- a/src/_data/meta.js
+++ b/src/_data/meta.js
@@ -96,3 +96,9 @@ export const analytics = {
     siteId: 'KVRCNWLT'
   }
 };
+export const carbonAds = {
+  enabled: true,
+  serve: 'CWBDPK3I',
+  placement: 'remoteintechcompany',
+  format: 'cover'
+};

--- a/src/_includes/partials/carbon-ad.njk
+++ b/src/_includes/partials/carbon-ad.njk
@@ -1,0 +1,24 @@
+{%- if meta.carbonAds.enabled and eleventy.env.runMode == "build" -%}
+<aside class="carbon-ad-container" aria-label="Sponsored content">
+  <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve={{ meta.carbonAds.serve }}&placement={{ meta.carbonAds.placement }}&format={{ meta.carbonAds.format }}" id="_carbonads_js"></script>
+</aside>
+<script>
+(function () {
+  var mq = window.matchMedia('(max-width: 960px)');
+  var ad = document.querySelector('.carbon-ad-container');
+  var main = document.getElementById('main');
+  var sidebarWrapper = ad ? ad.parentNode : null;
+  function reposition(e) {
+    if (!ad || !main) return;
+    if (e.matches) {
+      var target = main.querySelector('.hero, .company-profile__header') || main.querySelector('h1');
+      if (target) target.after(ad);
+    } else if (sidebarWrapper) {
+      sidebarWrapper.appendChild(ad);
+    }
+  }
+  mq.addEventListener('change', reposition);
+  reposition(mq);
+})();
+</script>
+{%- endif -%}

--- a/src/_layouts/base.njk
+++ b/src/_layouts/base.njk
@@ -56,7 +56,14 @@
     {% endset %}
     {% include "partials/header.njk" %}
 
+    {%- if meta.carbonAds.enabled and eleventy.env.runMode == "build" -%}
+    <div class="site-content sidebar" data-direction="rtl">
+      <main id="main" class="flow">{{ content | safe }}</main>
+      {% include "partials/carbon-ad.njk" %}
+    </div>
+    {%- else -%}
     <main id="main" class="flow">{{ content | safe }}</main>
+    {%- endif -%}
 
     {% include "partials/footer.njk" %}
   </body>

--- a/src/assets/css/global/blocks/carbon-ad.css
+++ b/src/assets/css/global/blocks/carbon-ad.css
@@ -10,11 +10,16 @@
   align-items: flex-start;
 }
 
-/* Sticky ad while scrolling (desktop) */
+/* Sticky ad while scrolling (desktop only) */
 .carbon-ad-container {
-  position: sticky;
-  top: var(--space-l);
   padding-block-start: var(--space-xl-2xl);
+}
+
+@media (min-width: 961px) {
+  .carbon-ad-container {
+    position: sticky;
+    top: var(--space-l);
+  }
 }
 
 /* Mobile: JS moves the ad inside main after the first section */

--- a/src/assets/css/global/blocks/carbon-ad.css
+++ b/src/assets/css/global/blocks/carbon-ad.css
@@ -1,0 +1,57 @@
+/* Sidebar wrapper takes over main's flex role in body layout */
+.site-content {
+  flex: auto;
+}
+
+/* Configure sidebar for ad layout */
+.site-content.sidebar {
+  --sidebar-target-width: 18rem;
+  --sidebar-content-min-width: 65%;
+  align-items: flex-start;
+}
+
+/* Sticky ad while scrolling (desktop) */
+.carbon-ad-container {
+  position: sticky;
+  top: var(--space-l);
+  padding-block-start: var(--space-xl-2xl);
+}
+
+/* Mobile: JS moves the ad inside main after the first section */
+@media (max-width: 960px) {
+  .site-content.sidebar {
+    --sidebar-content-min-width: 100%;
+  }
+
+  /* Hide ad while still in sidebar wrapper (before/without JS) */
+  .site-content > .carbon-ad-container {
+    display: none;
+  }
+
+  /* Style ad once inside main */
+  main > .carbon-ad-container {
+    position: static;
+    display: flex;
+    justify-content: center;
+    padding-block: var(--space-m);
+  }
+}
+
+/* Constrain Carbon ad width */
+#carbon-cover,
+#carbon-responsive {
+  max-width: 18rem;
+}
+
+/* Subtle dark mode adjustment for third-party ad styling */
+:root[data-theme='dark'] #carbon-cover,
+:root[data-theme='dark'] #carbon-responsive {
+  filter: brightness(0.9);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) #carbon-cover,
+  :root:not([data-theme='light']) #carbon-responsive {
+    filter: brightness(0.9);
+  }
+}

--- a/src/pages/changelog.njk
+++ b/src/pages/changelog.njk
@@ -32,7 +32,7 @@ description: 'Version history and changelog for Remote In Tech'
           {% for change in entry.changes %}
             <li>
               <span class="changelog-badge" data-type="{{ change.type }}">{{ change.type }}</span>
-              {{ change.description }}
+              {{ change.description | safe }}
             </li>
           {% endfor %}
         </ul>

--- a/src/pages/privacy.md
+++ b/src/pages/privacy.md
@@ -27,9 +27,15 @@ This website uses [Fathom Analytics](https://usefathom.com/), a privacy-focused 
 
 Fathom generates anonymous, aggregate statistics only. Individual visitors cannot be identified. You can read more about [Fathom's privacy compliance](https://usefathom.com/compliance).
 
+## Advertising
+
+This website displays ads through [Carbon Ads](https://www.carbonads.net/), an ethical ad network for developers and designers. Carbon Ads are context-based (served based on site content, not user profiles), developer-focused, and limited to one small, clearly labeled ad per page.
+
+Carbon Ads may use cookies for ad frequency capping and basic analytics. You can learn more about [Carbon's privacy practices](https://www.carbonads.net/privacy).
+
 ## Data Collection
 
-Beyond the anonymous analytics described above, this website does not collect any personal data. There are no sign-up forms, no accounts, and no cookies.
+Beyond the anonymous analytics and advertising described above, this website does not collect any personal data. There are no sign-up forms, no accounts, and no tracking cookies.
 
 ## Website Security
 
@@ -47,4 +53,4 @@ If you have any questions about this privacy policy, please [contact us](/contac
 
 If we change the content of this policy, those changes will be effective at the time we post them here.
 
-*Last updated: January 2025*
+*Last updated: March 2026*


### PR DESCRIPTION
## Summary

- Integrates [Carbon Ads](https://www.carbonads.net/) (ethical, developer-focused advertising) as a sidebar alongside the main content
- Only loads in production builds to keep dev environment clean
- Config is centralised in `src/_data/meta.js` with a kill-switch via `enabled` flag
- Updates privacy policy to disclose the ad integration

## Changes

- **`src/_data/meta.js`** — `carbonAds` config (serve URL, placement, enabled flag)
- **`src/_includes/partials/carbon-ad.njk`** — Ad partial with production-only guard
- **`src/_layouts/base.njk`** — Sidebar composition wrapping `<main>` + ad `<aside>` in production
- **`src/assets/css/global/blocks/carbon-ad.css`** — Cover format styles with classic fallback
- **`src/pages/privacy.md`** — Updated privacy policy with Carbon Ads disclosure
- **`CLAUDE.md`** — Documented the advertising setup

## Test plan

- [x] Verify ad loads correctly on Netlify deploy preview
- [x] Confirm ad does NOT render in dev (`npm run start`)
- [x] Check sidebar layout on desktop and mobile
- [x] Verify classic fallback renders when cover format unavailable
- [x] Review privacy policy page for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)