### PR TITLE
fix: correct Nozbe careers URL

### DIFF
--- a/src/companies/nozbe.md
+++ b/src/companies/nozbe.md
@@ -2,7 +2,7 @@
 title: "Nozbe"
 slug: nozbe
 website: https://nozbe.com/
-careers_url: https://nozbe.com/jobs
+careers_url: https://nozbe.com/job
 region: worldwide
 remote_policy: fully-remote
 company_size: small
@@ -39,4 +39,4 @@ Worldwide. The core team is Polish, but team members and contractors span four c
 
 ## How to apply
 
-Browse open roles at [nozbe.com/jobs](https://nozbe.com/jobs).
+Browse open roles at [nozbe.com/jobs](https://nozbe.com/job).


### PR DESCRIPTION
## Summary

The Nozbe `careers_url` added in #2165 pointed at `https://nozbe.com/jobs` which returns 404. The actual careers page lives at `https://nozbe.com/job` (singular). Fixed in both the frontmatter and the "How to apply" section.

## Test plan

- [x] `curl -I https://nozbe.com/job` returns 200
- [x] `node .github/scripts/validate-companies.js src/companies/nozbe.md` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)