### PR TITLE
docs: clarify "punch it" shorthand includes admin-merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Shorthand
 
-- **"Punch it"** = commit, push, and open a PR to upstream, all in one go.
+- **"Punch it"** = commit, push, open a PR to upstream, and squash-merge it with `--admin` (bypassing the branch-protection review requirement), all in one go. Delete the branch after merge.
 
 ## Project Overview
 


### PR DESCRIPTION
## Summary

Updates the `Shorthand` section of `CLAUDE.md` so that "punch it" explicitly includes the squash-merge with `--admin` and branch deletion, matching how the maintainer actually wants the workflow to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)