### PR TITLE
feat: Featured Companies revamp — fixed set of 8, shuffled per build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-in-tech",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "description": "A list of semi to fully remote-friendly companies in or around tech",
   "author": "Doug Aitken",
   "license": "ISC",

--- a/src/_data/changelog.json
+++ b/src/_data/changelog.json
@@ -1,5 +1,16 @@
 [
   {
+    "version": "4.10.0",
+    "date": "2026-05-07",
+    "summary": "Featured Companies revamp — fixed set of 8 companies, shuffled per build",
+    "changes": [
+      {
+        "type": "changed",
+        "description": "<a href=\"/\">Featured Companies</a> on the homepage now shows a fixed set of 8 companies (always shown, order randomized per build) instead of rotating 8 of 12"
+      }
+    ]
+  },
+  {
     "version": "4.9.0",
     "date": "2026-05-02",
     "summary": "Site-wide link rot cleanup — removed compromised profile, fixed 200+ broken or stale URLs (closes #1983)",

--- a/src/_data/companyHelpers.js
+++ b/src/_data/companyHelpers.js
@@ -29,19 +29,16 @@ export function getTechLabel(tech) {
 }
 
 /**
- * Featured companies list - manually curated high-quality examples
+ * Featured companies list - manually curated high-quality examples.
+ * All 8 are shown on the homepage; order is shuffled per build.
  */
 export const featuredCompanySlugs = [
-  'github',
-  'gitlab',
   'automattic',
+  'stripe',
+  'netlify',
+  'github',
+  'linear',
   'zapier',
   'buffer',
-  'doist',
-  'elastic',
-  'hashicorp',
-  'stripe',
-  'shopify',
-  'netlify',
   'vercel'
 ];


### PR DESCRIPTION
## Summary

- Trim `featuredCompanySlugs` from 12 to 8 — every featured company now appears on every build (no more rotating 8-of-12), but order is still shuffled per build so no slot is permanently #1
- New featured list: automattic, stripe, netlify, github, linear, zapier, buffer, vercel
- Bumps to v4.10.0 with a changelog entry

## Test plan

- [ ] Verify the homepage "Featured Companies" section shows all 8 companies
- [ ] Refresh a few times in production to confirm order shuffles between builds
- [ ] Confirm changelog page shows the new v4.10.0 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)