### PR TITLE
feat: add OpenRouter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-in-tech",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "description": "A list of semi to fully remote-friendly companies in or around tech",
   "author": "Doug Aitken",
   "license": "ISC",

--- a/src/_data/changelog.json
+++ b/src/_data/changelog.json
@@ -1,5 +1,16 @@
 [
   {
+    "version": "4.11.0",
+    "date": "2026-05-07",
+    "summary": "New company added — OpenRouter",
+    "changes": [
+      {
+        "type": "added",
+        "description": "Company: <a href=\"/companies/openrouter/\">OpenRouter</a>"
+      }
+    ]
+  },
+  {
     "version": "4.10.0",
     "date": "2026-05-07",
     "summary": "Featured Companies revamp — fixed set of 8 companies, shuffled per build",

--- a/src/companies/openrouter.md
+++ b/src/companies/openrouter.md
@@ -1,0 +1,42 @@
+---
+title: "OpenRouter"
+slug: openrouter
+website: https://openrouter.ai/
+careers_url: https://openrouter.ai/careers
+region: americas
+remote_policy: remote-first
+company_size: small
+technologies:
+  - ml
+  - cloud
+addedAt: 2026-05-07
+---
+
+## Company blurb
+
+[OpenRouter](https://openrouter.ai/) is a unified API marketplace for large language models. A single interface gives developers access to 400+ models from 60+ providers — including Anthropic, OpenAI, Google, Meta, and Microsoft — with automatic provider fallback during outages and edge-routed requests for lower latency.
+
+Founded in early 2023, OpenRouter was the first LLM marketplace and now serves 8M+ users and 250k+ apps, processing tens of trillions of tokens per month. The company has raised approximately $40M, backed by Andreessen Horowitz, Menlo Ventures, and Sequoia Capital.
+
+## Company size
+
+A small, focused team.
+
+## Remote status
+
+OpenRouter is remote-first with the flexibility to work from anywhere in the US. The team meets in person at quarterly offsites and offers an annual work-from-home budget alongside fully covered health, dental, and vision insurance, unlimited PTO, and competitive salary and equity.
+
+## Region
+
+Americas — currently hiring within the United States.
+
+## Company technologies
+
+- LLM aggregation across 400+ models from 60+ providers (Anthropic, OpenAI, Google, Meta, Microsoft, and others)
+- OpenAI-compatible API — drop-in support for the OpenAI SDK
+- Distributed, edge-routed inference infrastructure with provider failover
+- Credit-based pricing with no subscription required
+
+## How to apply
+
+See open roles at [openrouter.ai/careers](https://openrouter.ai/careers).


### PR DESCRIPTION
## Summary

- Adds [OpenRouter](https://openrouter.ai/) — a unified API marketplace for LLMs (400+ models from 60+ providers, founded 2023, ~$40M raised from a16z, Menlo, Sequoia)
- Remote-first, hiring within the US
- Bumps to v4.11.0 with a changelog entry

## Test plan

- [ ] Validation workflow passes
- [ ] Profile renders at /companies/openrouter/
- [ ] Changelog page shows the new v4.11.0 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)