### PR TITLE
Add SearchApi Company

### DIFF
--- a/src/companies/searchapi.md
+++ b/src/companies/searchapi.md
@@ -1,0 +1,43 @@
+---
+title: "SearchApi"
+slug: searchapi
+website: https://www.searchapi.io/
+careers_url: https://www.searchapi.io/careers
+region: worldwide
+remote_policy: fully-remote
+company_size: small
+technologies:
+  - ruby
+  - search
+  - python
+  - javascript
+  - devops
+---
+
+## Company blurb
+
+[SearchApi](https://www.searchapi.io/) is a real-time SERP (search engine results pages) API delivering structured data from a collection of search engines, including Google Search, Google Shopping, Google Jobs, Bing, Baidu, YouTube, Amazon, and many more.
+
+## Company size
+
+5-20
+
+## Remote status
+
+All of our employees are remote and we are from all over the world. We interact mostly using GitHub, Slack, e-mail, and various other tools.
+
+## Region
+
+Worldwide
+
+## Company technologies
+
+Ruby, Rails, Hotwire (Stimulus.JS + Turbo), TailwindCSS, PostgreSQL, Redis, Sidekiq, Terraform
+
+## Office locations
+
+No physical offices
+
+## How to apply
+
+You can view our open positions here: https://www.searchapi.io/careers


### PR DESCRIPTION
## Description

<!-- Briefly describe your changes -->

Re-adds SearchApi to the directory. It was originally added in #1831 but appears to have been removed during the October 2025 migration from company-profiles/ to src/companies/. This PR follows the new format.

## Type of Change

- [x] New company addition
- [ ] Company information update
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

### General Requirements
- [x] I have read the [Contributing Guidelines](https://github.com/remoteintech/remote-jobs/blob/main/.github/CONTRIBUTING.md)
- [x] This pull request adheres to the repository's Code of Conduct
- [x] I have tested the build locally with `npm run build:11ty`

### For Company Additions/Updates
- [x] Company file is in `src/companies/` with correct filename (lowercase, hyphenated)
- [x] The company directly hires employees (no bootcamps/freelance platforms)
- [x] The company offers genuine remote work opportunities

#### Frontmatter Requirements
- [x] `title` - Company name in quotes
- [x] `slug` - Matches filename (without .md)
- [x] `website` - Valid company URL
- [x] `region` - One of: `worldwide`, `americas`, `europe`, `americas-europe`, `asia-pacific`, `other`
- [x] `remote_policy` - One of: `fully-remote`, `remote-first`, `hybrid`, `remote-friendly`
- [x] `company_size` - One of: `tiny`, `small`, `medium`, `large`, `enterprise`
- [x] `technologies` - Array of valid tech tags (optional)
- [x] `careers_url` - Direct link to careers page (optional)
- **Note:** `addedAt` and `updatedAt` dates are managed by maintainers — do not include them

#### Content Requirements
- [x] "Company blurb" section describes what the company does
- [x] "Remote status" section details the remote work policy and culture
- [x] "How to apply" section includes application instructions

## Additional Information

<!-- Any other context about your changes -->

