### PR TITLE
chore: bump to 4.13.0 — two new companies + dep updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-in-tech",
-  "version": "4.12.0",
+  "version": "4.13.0",
   "description": "A list of semi to fully remote-friendly companies in or around tech",
   "author": "Doug Aitken",
   "license": "ISC",

--- a/src/_data/changelog.json
+++ b/src/_data/changelog.json
@@ -1,5 +1,24 @@
 [
   {
+    "version": "4.13.0",
+    "date": "2026-05-17",
+    "summary": "Two new companies — SearchApi and SEO Inc. — plus a round of dependency updates",
+    "changes": [
+      {
+        "type": "added",
+        "description": "Company: <a href=\"/companies/searchapi/\">SearchApi</a> — fully-remote, worldwide team building a real-time SERP API for Google, Bing, Baidu, YouTube, Amazon and more"
+      },
+      {
+        "type": "added",
+        "description": "Company: <a href=\"/companies/seo-inc/\">SEO Inc.</a> — remote-friendly U.S. digital marketing agency focused on SEO, PPC, and AI search optimization"
+      },
+      {
+        "type": "changed",
+        "description": "Dependency bumps: esbuild 0.25 → 0.28, colorjs.io 0.5 → 0.6, plus patch updates to @11ty/eleventy-fetch, postcss-colormin, and postcss-normalize-string"
+      }
+    ]
+  },
+  {
     "version": "4.12.0",
     "date": "2026-05-07",
     "summary": "New blog post — Anatomy of a Traffic Spike",


### PR DESCRIPTION
## Summary

- Bumps site version to **4.13.0**
- Adds changelog entry covering two newly merged company profiles and the round of Dependabot updates merged today

### What's in 4.13.0

- **Added** — [SearchApi](/companies/searchapi/) (#2184) — fully-remote, worldwide SERP API team
- **Added** — [SEO Inc.](/companies/seo-inc/) (#2185) — remote-friendly U.S. digital marketing agency
- **Changed** — Dependency bumps: esbuild 0.25 → 0.28 (#2181), colorjs.io 0.5 → 0.6 (#2183), plus patch updates to @11ty/eleventy-fetch (#2180), postcss-colormin (#2179), postcss-normalize-string (#2182)

Minor bump per the versioning policy — visitor-visible changes (new companies) dominate.

## Test plan

- [ ] CI build passes
- [ ] Netlify deploy preview renders /changelog/ with the new 4.13.0 entry at the top
- [ ] Footer version reads 4.13.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)