### PR TITLE
chore(deps): override liquidjs to 10.27.0 — close 6 alerts (v4.13.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remote-in-tech",
-  "version": "4.12.0",
+  "version": "4.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remote-in-tech",
-      "version": "4.12.0",
+      "version": "4.13.0",
       "license": "ISC",
       "dependencies": {
         "@11ty/eleventy": "^3.1.2",
@@ -3875,9 +3875,9 @@
       }
     },
     "node_modules/liquidjs": {
-      "version": "10.25.7",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.25.7.tgz",
-      "integrity": "sha512-rPCjJLiD4eDhQjvv964AeXFC+HbeYBbZrd7Z82Q6hqv1lX7G+5w4SJcKLn9CAAAwHI4aS3dTdo083UB79K3pDA==",
+      "version": "10.27.0",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.27.0.tgz",
+      "integrity": "sha512-tw/OA59K7aIBlMKIrKlumr37fiZUheShVHXY8cVctWisgY1p9mc5hreOvlreoS0wTiwlWk14Ya7305c2a/Cg5w==",
       "license": "MIT",
       "dependencies": {
         "commander": "^10.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-in-tech",
-  "version": "4.13.0",
+  "version": "4.13.1",
   "description": "A list of semi to fully remote-friendly companies in or around tech",
   "author": "Doug Aitken",
   "license": "ISC",
@@ -34,7 +34,8 @@
     "tailwindcss": "^3.4.17"
   },
   "overrides": {
-    "nanoid": "^5.0.9"
+    "nanoid": "^5.0.9",
+    "liquidjs": "^10.27.0"
   },
   "devDependencies": {
     "@toycode/markdown-it-class": "^1.2.4",

--- a/src/_data/changelog.json
+++ b/src/_data/changelog.json
@@ -1,5 +1,16 @@
 [
   {
+    "version": "4.13.1",
+    "date": "2026-05-30",
+    "summary": "Dependency security update — patched LiquidJS via npm override",
+    "changes": [
+      {
+        "type": "fixed",
+        "description": "Bumped <code>liquidjs</code> 10.25.7 → 10.27.0 via an npm <code>overrides</code> entry to close 6 Dependabot alerts, including a critical RCE and a high-severity ReDoS in the <code>strip_html</code> filter. As before, the affected template-engine features aren't used by this site, but worth closing out."
+      }
+    ]
+  },
+  {
     "version": "4.13.0",
     "date": "2026-05-17",
     "summary": "Two new companies — SearchApi and SEO Inc. — plus a round of dependency updates",


### PR DESCRIPTION
## Summary

- Adds a top-level npm `overrides` entry pinning `liquidjs` to `^10.27.0`, pulling the transitive dep from 10.25.7 → 10.27.0
- Closes 6 open LiquidJS Dependabot alerts:
  - **Critical** — RCE
  - **High** — ReDoS via quadratic backtracking in `strip_html` filter
  - **High** — Memory/render limit bypass via unbounded width padding in `date` filter (strftime)
  - **Medium** — `{% render %}` silently bypasses `ownPropertyOnly:true` via `Context.spawn()`
  - **Medium** — `renderLimit` DoS guard bypass via empty `{% for %}` body
  - **Medium** — `strip_html` bypass via newline characters in HTML tags (XSS)
- Bumps site to 4.13.1 with a changelog entry

None of the affected template-engine features are used by the site, but worth closing out (same reasoning as 4.11.1).

## Test plan

- [x] `npm install` resolves cleanly with the override applied
- [x] `npm ls liquidjs` shows 10.27.0
- [x] `npm run build:11ty` completes successfully
- [ ] CI build passes
- [ ] Dependabot alerts auto-close after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)