### PR TITLE
chore(deps): close ws + sanitize-html alerts (v4.13.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remote-in-tech",
-  "version": "4.13.0",
+  "version": "4.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remote-in-tech",
-      "version": "4.13.0",
+      "version": "4.13.1",
       "license": "ISC",
       "dependencies": {
         "@11ty/eleventy": "^3.1.2",
@@ -47,7 +47,7 @@
         "postcss-js": "^5.0.3",
         "prettier-plugin-jinja-template": "^2.1.0",
         "rimraf": "^6.1.3",
-        "sanitize-html": "^2.17.2",
+        "sanitize-html": "^2.17.4",
         "sharp": "^0.34.5",
         "sharp-ico": "^0.1.5",
         "slugify": "^1.6.6",
@@ -3847,6 +3847,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/launder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+      "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.11.7"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -5477,9 +5487,9 @@
       }
     },
     "node_modules/sanitize-html": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.3.tgz",
-      "integrity": "sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==",
+      "version": "2.17.4",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.4.tgz",
+      "integrity": "sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5487,6 +5497,7 @@
         "escape-string-regexp": "^4.0.0",
         "htmlparser2": "^10.1.0",
         "is-plain-object": "^5.0.0",
+        "launder": "^1.7.1",
         "parse-srcset": "^1.0.2",
         "postcss": "^8.3.11"
       }
@@ -6255,9 +6266,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-in-tech",
-  "version": "4.13.1",
+  "version": "4.13.2",
   "description": "A list of semi to fully remote-friendly companies in or around tech",
   "author": "Doug Aitken",
   "license": "ISC",
@@ -35,7 +35,8 @@
   },
   "overrides": {
     "nanoid": "^5.0.9",
-    "liquidjs": "^10.27.0"
+    "liquidjs": "^10.27.0",
+    "ws": "^8.21.0"
   },
   "devDependencies": {
     "@toycode/markdown-it-class": "^1.2.4",
@@ -67,7 +68,7 @@
     "postcss-js": "^5.0.3",
     "prettier-plugin-jinja-template": "^2.1.0",
     "rimraf": "^6.1.3",
-    "sanitize-html": "^2.17.2",
+    "sanitize-html": "^2.17.4",
     "sharp": "^0.34.5",
     "sharp-ico": "^0.1.5",
     "slugify": "^1.6.6",

--- a/src/_data/changelog.json
+++ b/src/_data/changelog.json
@@ -1,5 +1,20 @@
 [
   {
+    "version": "4.13.2",
+    "date": "2026-05-30",
+    "summary": "Dependency security update — closed the last two open Dependabot alerts (sanitize-html XSS, ws memory disclosure)",
+    "changes": [
+      {
+        "type": "fixed",
+        "description": "Bumped <code>sanitize-html</code> 2.17.3 → 2.17.4 to close a critical XSS alert (default config passed <code>&lt;xmp&gt;</code> raw-text content through unsanitised). Only used at build time on company-blurb HTML, but worth closing out."
+      },
+      {
+        "type": "fixed",
+        "description": "Added a <code>ws</code> override pulling 8.18.3 → 8.21.0 to close a medium-severity uninitialized-memory-disclosure alert. <code>ws</code> is a transitive dep of <code>@11ty/eleventy-dev-server</code>, only active during <code>npm run start</code>."
+      }
+    ]
+  },
+  {
     "version": "4.13.1",
     "date": "2026-05-30",
     "summary": "Dependency security update — patched LiquidJS via npm override",


### PR DESCRIPTION
## Summary

Closes the last two open Dependabot alerts:

- **Critical** — `sanitize-html` 2.17.3 → 2.17.4 (Apostrophe XSS via `<xmp>` raw-text passthrough). Direct devDep — bumped the version constraint.
- **Medium** — `ws` 8.18.3 → 8.21.0 (uninitialized memory disclosure). Added to `overrides` since `ws` is transitive via `@11ty/eleventy-dev-server` and only runs locally during `npm run start`.

Bumps site to **4.13.2** (patch — invisible to visitors). After this lands, the repo has zero open Dependabot alerts.

Supersedes the auto-opened Dependabot PRs #2187 (sanitize-html) and #2195 (ws). #2193 (liquidjs) was also superseded by #2196.

## Test plan

- [x] `npm install` resolves cleanly with the new override + bump
- [x] `npm ls ws sanitize-html` shows 8.21.0 / 2.17.4
- [x] `npm run build:11ty` completes successfully
- [ ] CI build passes
- [ ] All remaining Dependabot alerts auto-close after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)