### PR TITLE
fix(ci): handle multi-file PRs in validate-companies workflow

### DIFF
--- a/.github/workflows/validate-companies.yml
+++ b/.github/workflows/validate-companies.yml
@@ -47,14 +47,19 @@ jobs:
       - name: Run validation
         id: validate
         if: steps.changed.outputs.files != ''
+        env:
+          CHANGED_FILES: ${{ steps.changed.outputs.files }}
         run: |
           set +e
-          # Remap file paths to the PR checkout directory
-          MAPPED_FILES=""
-          for f in ${{ steps.changed.outputs.files }}; do
-            MAPPED_FILES="$MAPPED_FILES pr-head/$f"
-          done
-          RESULT=$(node .github/scripts/validate-companies.js $MAPPED_FILES)
+          # Remap file paths to the PR checkout directory. Read line-by-line
+          # into an array so multi-file PRs don't break shell syntax, and so
+          # filenames are passed to node as properly quoted argv entries.
+          MAPPED_FILES=()
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            MAPPED_FILES+=("pr-head/$f")
+          done <<< "$CHANGED_FILES"
+          RESULT=$(node .github/scripts/validate-companies.js "${MAPPED_FILES[@]}")
           EXIT_CODE=$?
           set -e
           echo "json<<EOF" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

The `Run validation` step in `.github/workflows/validate-companies.yml` substituted the changed-files list directly into a `for f in ${{ ... }}; do ...` loop. For single-file PRs that produced valid bash, but for multi-file PRs the newlines landed in the middle of the `for` statement and bash failed.

Observed on PR #2188 (4 new company files), with the runner log showing:

\`\`\`
for f in src/companies/Cal.com.md
src/companies/Raycast.md
src/companies/Retool.md
src/companies/plaid.md; do
  ...
/home/runner/work/_temp/...sh: line 5: syntax error near unexpected token \`src/companies/Raycast.md'
\`\`\`

## Fix

- Pass the changed-files list through a `CHANGED_FILES` env var instead of substituting it into shell syntax.
- Read it line-by-line into a bash array with `while IFS= read -r`.
- Invoke node with `"${MAPPED_FILES[@]}"` so each filename is passed as a properly quoted argv entry.

The quoted-argv part also matters from a hardening perspective: this workflow runs under `pull_request_target`, so the filenames are PR-controlled content. The previous unquoted `$MAPPED_FILES` would have allowed a crafted filename with shell metacharacters; the array form prevents that.

## Test plan

- [ ] CI passes on this PR (no company files touched, validate step is skipped via the `if: steps.changed.outputs.files != ''` guard)
- [ ] After merge, re-run validation on #2188 to confirm the multi-file case validates without bash erroring out
- [ ] Single-file contributor PRs continue to validate as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)