### PR TITLE
feat: expand tech tag vocabulary + DRY validator enums (v4.13.3)

### DIFF
--- a/.github/scripts/validate-companies.js
+++ b/.github/scripts/validate-companies.js
@@ -10,46 +10,15 @@
 
 import { readFileSync } from "node:fs";
 import { basename } from "node:path";
+import labels from "../../src/_data/labels.js";
 
-// Canonical enum values (from src/_data/companyHelpers.js)
-const VALID_REGIONS = [
-  "worldwide",
-  "americas",
-  "europe",
-  "americas-europe",
-  "asia-pacific",
-  "other",
-];
-
-const VALID_REMOTE_POLICIES = [
-  "fully-remote",
-  "remote-first",
-  "hybrid",
-  "remote-friendly",
-];
-
-const VALID_COMPANY_SIZES = ["tiny", "small", "medium", "large", "enterprise"];
-
-const VALID_TECHNOLOGIES = [
-  "javascript",
-  "python",
-  "ruby",
-  "go",
-  "java",
-  "php",
-  "rust",
-  "dotnet",
-  "elixir",
-  "scala",
-  "cloud",
-  "devops",
-  "mobile",
-  "data",
-  "ml",
-  "sql",
-  "nosql",
-  "search",
-];
+// Canonical enum values — keys come from the same labels.js the site renders
+// from, so adding a tag/region/etc. in one place updates validation too.
+const l = labels();
+const VALID_REGIONS = Object.keys(l.region);
+const VALID_REMOTE_POLICIES = Object.keys(l.remotePolicy);
+const VALID_COMPANY_SIZES = Object.keys(l.companySize);
+const VALID_TECHNOLOGIES = Object.keys(l.tech);
 
 const REQUIRED_FIELDS = [
   "title",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-in-tech",
-  "version": "4.13.2",
+  "version": "4.13.3",
   "description": "A list of semi to fully remote-friendly companies in or around tech",
   "author": "Doug Aitken",
   "license": "ISC",

--- a/src/_data/changelog.json
+++ b/src/_data/changelog.json
@@ -1,5 +1,24 @@
 [
   {
+    "version": "4.13.3",
+    "date": "2026-05-30",
+    "summary": "Expanded the tech tag vocabulary and fixed the validation workflow for multi-file PRs",
+    "changes": [
+      {
+        "type": "added",
+        "description": "Added seven tech tags that contributors commonly want: <code>typescript</code>, <code>react</code>, <code>nodejs</code>, <code>swift</code>, <code>docker</code>, <code>kubernetes</code>, and <code>postgres</code> (PostgreSQL). Tags only appear on the <a href=\"/tags/\">browse pages</a> once a company uses them — adding the labels is a no-op until profiles opt in."
+      },
+      {
+        "type": "changed",
+        "description": "Consolidated the validator's enum lists (regions / remote policies / company sizes / technologies) to import from <code>src/_data/labels.js</code>, so future tag changes only need to happen in one place."
+      },
+      {
+        "type": "fixed",
+        "description": "Fixed the <code>Validate Company Profiles</code> workflow to handle multi-file PRs. Previously the changed-files list was substituted directly into a bash <code>for</code> loop, which crashed with a syntax error whenever a PR touched more than one company file."
+      }
+    ]
+  },
+  {
     "version": "4.13.2",
     "date": "2026-05-30",
     "summary": "Dependency security update — closed the last two open Dependabot alerts (sanitize-html XSS, ws memory disclosure)",

--- a/src/_data/labels.js
+++ b/src/_data/labels.js
@@ -28,6 +28,9 @@ export default function () {
     },
     tech: {
       'javascript': 'JavaScript',
+      'typescript': 'TypeScript',
+      'react': 'React',
+      'nodejs': 'Node.js',
       'python': 'Python',
       'ruby': 'Ruby',
       'go': 'Go',
@@ -37,12 +40,16 @@ export default function () {
       'dotnet': '.NET',
       'elixir': 'Elixir',
       'scala': 'Scala',
+      'swift': 'Swift',
       'cloud': 'Cloud',
       'devops': 'DevOps',
+      'docker': 'Docker',
+      'kubernetes': 'Kubernetes',
       'mobile': 'Mobile',
       'data': 'Data',
       'ml': 'ML/AI',
       'sql': 'SQL',
+      'postgres': 'PostgreSQL',
       'nosql': 'NoSQL',
       'search': 'Search'
     }


### PR DESCRIPTION
## Summary

- **Adds seven tech tags** that contributors keep reaching for (most recently on #2188):
  - \`typescript\` → TypeScript
  - \`react\` → React
  - \`nodejs\` → Node.js
  - \`swift\` → Swift
  - \`docker\` → Docker
  - \`kubernetes\` → Kubernetes
  - \`postgres\` → PostgreSQL
- **DRYs up validator enums**: \`.github/scripts/validate-companies.js\` now imports its valid regions / remote-policies / company-sizes / technology lists from \`src/_data/labels.js\` instead of maintaining a duplicate copy.
- Bumps to **4.13.3** and folds the workflow multi-file fix from #2198 into the changelog entry (it hadn't been released yet).

## Why

The validator's enum lists had already silently diverged from the labels the site templates accept, and the tech-tag list in particular was too narrow — common stacks like TypeScript / React / Node.js / Postgres / Kubernetes weren't allowed. With this change, contributors can use those tags and the validator passes them through, but no empty \`/browse/<tag>/\` pages get generated until a company actually uses the tag (the tag collection only emits keys with ≥1 company).

A broader tag-vocabulary review is on the wishlist — this PR just clears the obvious wins.

## Test plan

- [x] \`node .github/scripts/validate-companies.js src/companies/automattic.md\` returns \`passed: 1\`
- [x] \`npm run build:11ty\` writes the same 971 files (no new empty browse pages)
- [ ] CI passes
- [ ] After merge, \`Validate Company Profiles\` on a contributor PR that uses one of the new tags doesn't flag them

🤖 Generated with [Claude Code](https://claude.com/claude-code)