### PR TITLE
Add Dribbble company profile

### DIFF
--- a/src/companies/dribbble.md
+++ b/src/companies/dribbble.md
@@ -1,0 +1,40 @@
+---
+title: "Dribbble"
+slug: dribbble
+website: https://dribbble.com
+careers_url: https://dribbble.com/careers/
+region: americas
+remote_policy: fully-remote
+company_size: medium
+technologies:
+  - javascript
+  - ruby
+  - sql
+  - cloud
+  - search
+  - nosql
+---
+
+## Company blurb
+
+Dribbble is the world's leading online community for designers and creative professionals to showcase their work, find inspiration, and get hired. Founded in 2009, it serves tens of millions of designers and helps design-forward companies discover and recruit creative talent. The platform brings together portfolios, feedback, education, and job opportunities in one place, and is regularly listed among the world's top 1,000 websites.
+
+## Remote status
+
+Dribbble is a 100% distributed, remote-first company. The team works from anywhere, with a culture built around asynchronous collaboration, frequent written communication, and at least one in-person retreat each year. They state explicitly that they are "Remote-first, always," offering flexible schedules, generous paid time off, and fully remote benefits (medical, dental, home-office equipment, and a learning stipend).
+
+## How to apply
+
+Open roles are listed on the Dribbble careers page. Review the available positions and submit your application directly through the form linked there.
+
+## Company size
+
+A small-to-midsized team (tens of employees) that operates entirely remotely.
+
+## Region
+
+Primarily North America, with a fully distributed team working across time zones.
+
+## Company technologies
+
+The product is built with Vanilla JavaScript and Vue.js on the front end, backed by Ruby on Rails, PostgreSQL, Elasticsearch, Redis/Memcached, and AWS.


### PR DESCRIPTION
Add Dribbble to the remote company directory.

Sources:/n- Official careers page states the team is 100% distributed / remote-first.
- Tech stack from public job descriptions (Vanilla JS, Vue.js, Ruby on Rails, PostgreSQL, Elasticsearch, Redis, AWS).

Closes part of #2040.