### PR TITLE
fix(ci): allow fork checkout in company validation workflow

### DIFF
--- a/.github/workflows/validate-companies.yml
+++ b/.github/workflows/validate-companies.yml
@@ -33,6 +33,10 @@ jobs:
           sparse-checkout: |
             src/companies
             company-profiles
+          # Safe here: sparse-checkout limits this to data files (company
+          # profiles) only, never .github/ workflows or scripts, and nothing
+          # from the fork is executed. See https://gh.io/securely-using-pull_request_target
+          allow-unsafe-pr-checkout: true
 
       - name: Get changed files
         id: changed


### PR DESCRIPTION
## Summary
- GitHub Actions now blocks `pull_request_target` workflows from checking out fork PR code by default (pwn-request protection), which was silently failing the "Validate Company Profiles" check on every contributor PR touching company files (e.g. #2238).
- Opts in via `allow-unsafe-pr-checkout: true` on the "Checkout PR company files" step, safe here because `sparse-checkout` limits it to `src/companies` / `company-profiles` data files only — no workflows or scripts from the fork are ever checked out or executed.

## Test plan
- [ ] Confirm the "Validate Company Profiles" check passes on #2238 after this merges