### PR TITLE
fix(ci): don't persist token in fork PR checkout

### DIFF
--- a/.github/workflows/validate-companies.yml
+++ b/.github/workflows/validate-companies.yml
@@ -37,6 +37,9 @@ jobs:
           # profiles) only, never .github/ workflows or scripts, and nothing
           # from the fork is executed. See https://gh.io/securely-using-pull_request_target
           allow-unsafe-pr-checkout: true
+          # Defense-in-depth: don't persist the workflow token into this
+          # fork-controlled checkout's .git/config.
+          persist-credentials: false
 
       - name: Get changed files
         id: changed


### PR DESCRIPTION
## Summary
- Copilot's review on #2239 flagged that the fork-controlled "Checkout PR company files" checkout still persisted the workflow's `GITHUB_TOKEN` into its `.git/config`.
- Sets `persist-credentials: false` on that step as defense-in-depth — doesn't change validation behavior.

## Test plan
- [ ] Confirm "Validate Company Profiles" still passes on a company-file PR after this merges