### PR TITLE
fix(ci): don't validate company files a PR removed

### DIFF
--- a/.github/workflows/validate-companies.yml
+++ b/.github/workflows/validate-companies.yml
@@ -44,7 +44,15 @@ jobs:
       - name: Get changed files
         id: changed
         run: |
-          FILES=$(gh pr diff ${{ github.event.pull_request.number }} --name-only | grep -E '(^src/companies/.*\.md$|^company-profiles/)' || true)
+          # List changed files via the API rather than `gh pr diff --name-only`,
+          # so we can filter on each file's status. A PR that renames or deletes
+          # a company profile reports the old path too, and that path does not
+          # exist in the pr-head checkout — validating it failed with ENOENT and
+          # blocked the PR on a file it had legitimately removed.
+          FILES=$(gh api \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --paginate -q '.[] | select(.status != "removed") | .filename' \
+            | grep -E '(^src/companies/.*\.md$|^company-profiles/)' || true)
           echo "files<<EOF" >> "$GITHUB_OUTPUT"
           echo "$FILES" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
@@ -64,8 +72,22 @@ jobs:
           MAPPED_FILES=()
           while IFS= read -r f; do
             [ -z "$f" ] && continue
+            # Belt and braces: the status filter above should mean every path
+            # here exists, so warn rather than skip silently if one does not.
+            if [ ! -f "pr-head/$f" ]; then
+              echo "::warning::Skipping $f — not present in the PR checkout"
+              continue
+            fi
             MAPPED_FILES+=("pr-head/$f")
           done <<< "$CHANGED_FILES"
+          if [ ${#MAPPED_FILES[@]} -eq 0 ]; then
+            echo "No company files to validate."
+            echo "json<<EOF" >> "$GITHUB_OUTPUT"
+            echo '{"oldFormatFiles":[],"files":{},"summary":{"total":0,"passed":0,"failed":0,"warnings":0}}' >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+            echo "exit_code=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           RESULT=$(node .github/scripts/validate-companies.js "${MAPPED_FILES[@]}")
           EXIT_CODE=$?
           set -e

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remote-in-tech",
-  "version": "4.13.5",
+  "version": "4.13.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remote-in-tech",
-      "version": "4.13.5",
+      "version": "4.13.6",
       "license": "ISC",
       "dependencies": {
         "@11ty/eleventy": "^3.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-in-tech",
-  "version": "4.13.5",
+  "version": "4.13.6",
   "description": "A list of semi to fully remote-friendly companies in or around tech",
   "author": "Doug Aitken",
   "license": "ISC",

--- a/src/_data/changelog.json
+++ b/src/_data/changelog.json
@@ -1,5 +1,16 @@
 [
   {
+    "version": "4.13.6",
+    "date": "2026-09-07",
+    "summary": "Fixed the company validation workflow blocking any PR that renames or removes a profile",
+    "changes": [
+      {
+        "type": "fixed",
+        "description": "The <code>Validate Company Profiles</code> workflow built its file list from <code>gh pr diff --name-only</code>, which reports both the old and new path when a PR renames a company profile. The old path no longer exists in the PR checkout, so validation died with <code>ENOENT</code> and blocked the PR over a file it had legitimately deleted — the same failure hit any PR removing a profile. The workflow now lists changed files through the API and filters out <code>removed</code> entries, so only files actually present get validated."
+      }
+    ]
+  },
+  {
     "version": "4.13.5",
     "date": "2026-09-07",
     "summary": "Dependency maintenance — cleared the Dependabot backlog and refreshed in-range minors, dropping the audit count from 9 vulnerabilities to 2",


### PR DESCRIPTION
Surfaced while reviewing #2247, but fixed independently since it affects every contributor PR of this shape.

### The bug

`validate-companies.yml` built its file list from `gh pr diff --name-only`. On a rename that returns **both** paths:

```
src/companies/redlio-designs.md   <- deleted by the PR
src/companies/redlio-labs.md
```

The mapping loop then prefixes each with `pr-head/`, but the deleted file isn't in the sparse head checkout, so `validate-companies.js` failed:

```
Could not read file: ENOENT: no such file or directory,
open 'pr-head/src/companies/redlio-designs.md'
```

That's an unconditional `exit 1`, so the workflow blocked the PR over a file it had legitimately deleted — while the file it actually added validated clean. Any PR **removing** a profile hit the same wall.

### The fix

List changed files through the pulls API and drop `removed` entries, so only paths present in the checkout are validated. This is preferable to just testing `-f` on each path, which would mask a genuinely missing file.

Verified against the live PRs:

| PR | Shape | Before | After |
|---|---|---|---|
| #2247 | rename | both paths → ENOENT | `redlio-labs.md` only |
| #2249 | edit | `soshace.md` | `soshace.md` (unchanged) |
| #2250 | add | `first-point.md` | `first-point.md` (unchanged) |

The mapping loop keeps a `-f` check as defence-in-depth, but now emits `::warning::` instead of skipping silently, and the step short-circuits cleanly if nothing is left to validate (the comment step already returns early on an empty result, so no comment is posted).

### Verification

YAML parses, mapping-loop logic exercised locally across rename / all-missing / multi-file cases, and `npm run build` is clean (981 files).

Credit to @mayursinh1211, who diagnosed this correctly on #2247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMca9WXKJAriMEfghGw1eT