### PR TITLE
chore: release v4.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-in-tech",
-  "version": "4.13.6",
+  "version": "4.14.0",
   "description": "A list of semi to fully remote-friendly companies in or around tech",
   "author": "Doug Aitken",
   "license": "ISC",

--- a/src/_data/changelog.json
+++ b/src/_data/changelog.json
@@ -1,5 +1,24 @@
 [
   {
+    "version": "4.14.0",
+    "date": "2026-09-09",
+    "summary": "Two new companies — First Point and Meduzzen — plus the Redlio Designs rebrand to Redlio Labs",
+    "changes": [
+      {
+        "type": "added",
+        "description": "Company: <a href=\"/companies/first-point/\">First Point</a> — fully-remote product studio building consumer iOS and Android apps, AI agent tooling and blockchain infrastructure"
+      },
+      {
+        "type": "added",
+        "description": "Company: <a href=\"/companies/meduzzen/\">Meduzzen</a> — Ukrainian AI and machine learning development company, fully remote with EU timezone coverage"
+      },
+      {
+        "type": "changed",
+        "description": "Company: <a href=\"/companies/redlio-designs/\">Redlio Designs</a> has rebranded to <a href=\"/companies/redlio-labs/\">Redlio Labs</a>. Profile refreshed by the company — new domain, working careers link (the old <code>/career</code> path 404s), current service list and expanded tech tags. The old profile URLs now redirect to the new one"
+      }
+    ]
+  },
+  {
     "version": "4.13.6",
     "date": "2026-09-07",
     "summary": "Fixed the company validation workflow blocking any PR that renames or removes a profile",


### PR DESCRIPTION
Version bump and changelog for the three profile PRs merged today.

- **added** — Company: [First Point](/companies/first-point/) (#2250)
- **added** — Company: [Meduzzen](/companies/meduzzen/) (#2201)
- **changed** — Redlio Designs rebranded to [Redlio Labs](/companies/redlio-labs/) (#2247), with `redirectFrom` covering `/companies/redlio-designs/` and `/redlio-designs`

Minor bump: new companies are visible to visitors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WgFuMrm8XmgmSSQUuNkFDA