### PR TITLE
docs: refresh contributor guidelines (v4.14.1)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -19,6 +19,7 @@ Thank you for your interest in contributing! This repository maintains a list of
 - Company directly hires employees (no bootcamps/freelance platforms)
 - Company offers genuine remote work opportunities
 - Company is in or around the tech industry
+- `careers_url` points at the company's own careers page, not a page selling its services to clients
 
 ### Steps
 
@@ -103,8 +104,8 @@ Instructions for applying, including links to careers page.
 - `enterprise` - 1000+ employees
 
 **technologies** (optional array):
-- `javascript`, `python`, `ruby`, `go`, `java`, `php`, `rust`, `dotnet`, `elixir`, `scala`
-- `cloud`, `devops`, `mobile`, `data`, `ml`, `sql`, `nosql`, `search`
+- `javascript`, `typescript`, `react`, `nodejs`, `python`, `ruby`, `go`, `java`, `php`, `rust`, `dotnet`, `elixir`, `scala`, `swift`
+- `cloud`, `devops`, `docker`, `kubernetes`, `mobile`, `data`, `ml`, `sql`, `postgres`, `nosql`, `search`
 
 **careers_url** (optional):
 - Direct link to the company's careers/jobs page
@@ -132,15 +133,20 @@ npm run build:11ty
 
 ## Content Guidelines
 
-### Required Markdown Sections
+### Markdown Sections
+
+These three are required, and the validation workflow will block a PR without them:
 
 1. **Company blurb** - What the company does
-2. **Company size** - Approximate employee count
-3. **Remote status** - Remote work policy and culture (be detailed!)
-4. **Region** - Where the company hires from
-5. **Company technologies** - Main tech stack
-6. **Office locations** - Physical offices (if any)
-7. **How to apply** - Application process and links
+2. **Remote status** - Remote work policy and culture (be detailed!)
+3. **How to apply** - Application process and links
+
+These are optional but commonly used, and worth filling in:
+
+4. **Company size** - Approximate employee count
+5. **Region** - Where the company hires from
+6. **Company technologies** - Main tech stack
+7. **Office locations** - Physical offices (if any)
 
 ### Content Quality Standards
 

--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -19,8 +19,9 @@
 
 ### For Company Additions/Updates
 - [ ] Company file is in `src/companies/` with correct filename (lowercase, hyphenated)
-- [ ] The company directly hires employees (no bootcamps/freelance platforms)
-- [ ] The company offers genuine remote work opportunities
+- [ ] The company directly hires employees (no bootcamps/staffing agencies/freelance platforms)
+- [ ] The company offers genuine remote work opportunities (salaried or hourly, not commission-only)
+- [ ] The company is in or around the tech industry
 
 #### Frontmatter Requirements
 - [ ] `title` - Company name in quotes
@@ -30,7 +31,7 @@
 - [ ] `remote_policy` - One of: `fully-remote`, `remote-first`, `hybrid`, `remote-friendly`
 - [ ] `company_size` - One of: `tiny`, `small`, `medium`, `large`, `enterprise`
 - [ ] `technologies` - Array of valid tech tags (optional)
-- [ ] `careers_url` - Direct link to careers page (optional)
+- [ ] `careers_url` - Direct link to the company's own careers page, not a page selling its services (optional)
 - **Note:** `addedAt` and `updatedAt` dates are managed by maintainers — do not include them
 
 #### Content Requirements

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,8 +42,8 @@ Optional but commonly used: `## Company size`, `## Region`, `## Company technolo
 |-------|----------------|
 | `region` | `worldwide`, `americas`, `europe`, `americas-europe`, `asia-pacific`, `other` |
 | `remote_policy` | `fully-remote`, `remote-first`, `hybrid`, `remote-friendly` |
-| `company_size` | `tiny`, `small`, `medium`, `large`, `enterprise` |
-| `technologies` | any of: `javascript`, `python`, `ruby`, `go`, `java`, `php`, `rust`, `dotnet`, `elixir`, `scala`, `cloud`, `devops`, `mobile`, `data`, `ml`, `sql`, `nosql`, `search` |
+| `company_size` | `tiny` (1-10), `small` (11-50), `medium` (51-200), `large` (201-1000), `enterprise` (1000+) |
+| `technologies` | any of: `javascript`, `typescript`, `react`, `nodejs`, `python`, `ruby`, `go`, `java`, `php`, `rust`, `dotnet`, `elixir`, `scala`, `swift`, `cloud`, `devops`, `docker`, `kubernetes`, `mobile`, `data`, `ml`, `sql`, `postgres`, `nosql`, `search` |
 
 > The `addedAt` and `updatedAt` date fields are managed by maintainers — please don't include them in your PR.
 
@@ -53,11 +53,24 @@ PRs that touch company files are automatically validated by the **Validate Compa
 
 If the bot mentions an "older file format" (e.g. files in `company-profiles/` or changes to `README.md`), please update your PR to use the format above.
 
+## What Belongs in the Directory
+
+Remote In Tech lists **semi to fully remote-friendly companies in or around tech**. Before opening a PR, check the company meets all of these:
+
+- You are an employee of the company, or can otherwise verify the information
+- The company directly hires employees — no bootcamps, staffing agencies or freelance platforms listing other companies' roles
+- The company offers genuine remote work opportunities — salaried or hourly roles that can be done remotely. Commission-only or independent contractor sales opportunities don't count
+- The company is in or around the tech industry
+- `careers_url` points at the company's own careers page, not a page selling its services to clients
+
 ## What Maintainers Will Reject
 
+- Companies that don't meet the criteria above
 - Companies promoting harmful services (hacking tools, spam, etc.)
 - Profiles with minimal or no meaningful content
 - Duplicates of existing companies — search `src/companies/` first
+
+If a listed company's business changes so it no longer meets the criteria, we normally remove the profile rather than rewrite it.
 
 ## Other Contributions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-in-tech",
-  "version": "4.14.0",
+  "version": "4.14.1",
   "description": "A list of semi to fully remote-friendly companies in or around tech",
   "author": "Doug Aitken",
   "license": "ISC",

--- a/src/_data/changelog.json
+++ b/src/_data/changelog.json
@@ -1,5 +1,28 @@
 [
   {
+    "version": "4.14.1",
+    "date": "2026-09-09",
+    "summary": "Refreshed the contributor guidelines so all three copies match the validator",
+    "changes": [
+      {
+        "type": "fixed",
+        "description": "The technology tag list was stale in all three contributor docs — <a href=\"/contributing/\">the site's contributing page</a>, <code>CONTRIBUTING.md</code> and <code>.github/CONTRIBUTING.md</code> — missing <code>typescript</code>, <code>react</code>, <code>nodejs</code>, <code>swift</code>, <code>docker</code>, <code>kubernetes</code> and <code>postgres</code>, which have been valid since v4.13.3. All three now match <code>src/_data/labels.js</code>, the source of truth the validator reads"
+      },
+      {
+        "type": "fixed",
+        "description": "<code>.github/CONTRIBUTING.md</code> listed seven required Markdown sections when the validator only requires three (<code>Company blurb</code>, <code>Remote status</code>, <code>How to apply</code>). The other four are now correctly marked optional"
+      },
+      {
+        "type": "added",
+        "description": "Eligibility criteria now appear in the guidelines themselves, not just the pull request template — what belongs in the directory, and what maintainers will reject. Adds a note that <code>careers_url</code> must point at a company's own careers page rather than a page selling its services"
+      },
+      {
+        "type": "changed",
+        "description": "Company size values in <code>CONTRIBUTING.md</code> now show their employee ranges, matching the labels used on the site"
+      }
+    ]
+  },
+  {
     "version": "4.14.0",
     "date": "2026-09-09",
     "summary": "Two new companies — First Point and Meduzzen — plus the Redlio Designs rebrand to Redlio Labs",

--- a/src/pages/contributing.md
+++ b/src/pages/contributing.md
@@ -9,6 +9,18 @@ layout: page
 
 We welcome contributions from everyone! Here's how you can help improve Remote In Tech.
 
+### What Belongs Here
+
+Remote In Tech lists semi to fully remote-friendly companies in or around tech. Before opening a pull request, check the company meets all of these:
+
+- You are an employee of the company, or can otherwise verify the information
+- The company directly hires employees — no bootcamps, staffing agencies or freelance platforms listing other companies' roles
+- The company offers genuine remote work opportunities — salaried or hourly roles that can be done remotely. Commission-only or independent contractor sales opportunities don't count
+- The company is in or around the tech industry
+- `careers_url` points at the company's own careers page, not a page selling its services to clients
+
+We also reject companies promoting harmful services, profiles with minimal or no meaningful content, and duplicates of companies already listed.
+
 ### Adding a New Company
 
 1. Fork the [Remote In Tech repository](https://github.com/remoteintech/remote-jobs)
@@ -70,7 +82,7 @@ Link to careers page or application instructions.
 
 **company_size**: `tiny` (1-10), `small` (11-50), `medium` (51-200), `large` (201-1000), `enterprise` (1000+)
 
-**technologies**: `javascript`, `python`, `ruby`, `go`, `java`, `php`, `rust`, `dotnet`, `elixir`, `scala`, `cloud`, `devops`, `mobile`, `data`, `ml`, `sql`, `nosql`, `search`
+**technologies**: `javascript`, `typescript`, `react`, `nodejs`, `python`, `ruby`, `go`, `java`, `php`, `rust`, `dotnet`, `elixir`, `scala`, `swift`, `cloud`, `devops`, `docker`, `kubernetes`, `mobile`, `data`, `ml`, `sql`, `postgres`, `nosql`, `search`
 
 ### Updating Existing Information
 


### PR DESCRIPTION
The repo carries **three** copies of contributor guidance — `CONTRIBUTING.md`, `.github/CONTRIBUTING.md` (the one GitHub surfaces and the PR template links to) and `src/pages/contributing.md` (the `/contributing/` page). They had drifted from each other and from `src/_data/labels.js`.

### Fixed

- **Stale tech tag list in all three.** Missing `typescript`, `react`, `nodejs`, `swift`, `docker`, `kubernetes`, `postgres` — valid since v4.13.3. A contributor reading any of these docs would have thought a valid tag was invalid.
- **`.github/CONTRIBUTING.md` listed 7 required Markdown sections.** The validator requires 3 (`Company blurb`, `Remote status`, `How to apply`); the other 4 are optional. Now says so.

### Added

- **Eligibility criteria in the guidelines themselves.** They previously existed only in `.github/CONTRIBUTING.md` and the PR template, so the root `CONTRIBUTING.md` and the public `/contributing/` page gave no stated grounds for rejecting an out-of-scope submission — which came up closing #2249.
- **A `careers_url` criterion**: it must point at the company's own careers page, not a page selling its services to clients (the #2201 failure mode).
- Employee ranges on `company_size` in `CONTRIBUTING.md`, matching the site labels.

All four value lists now match `labels.js` exactly, verified programmatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WgFuMrm8XmgmSSQUuNkFDA